### PR TITLE
[#12] New Persistent Stores Model

### DIFF
--- a/Sources/YMFF/FeatureFlag/FeatureFlagKey.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlagKey.swift
@@ -9,11 +9,9 @@
 /// A structure that contains information about the keys used to retrieve feature flag values from the corresponding stores.
 public struct FeatureFlagKey {
     
-    let localKey: String
     let remoteKey: String
     
-    private init(local localKey: String, remote remoteKey: String) {
-        self.localKey = localKey
+    private init(remote remoteKey: String) {
         self.remoteKey = remoteKey
     }
     
@@ -21,7 +19,7 @@ public struct FeatureFlagKey {
     ///
     /// - Parameter key: *Required.* The key to use for value retrieval.
     public init(_ key: String) {
-        self.init(local: key, remote: key)
+        self.init(remote: key)
     }
     
 }

--- a/Sources/YMFF/FeatureFlagResolver/Configuration/FeatureFlagResolverConfigurationProtocol.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Configuration/FeatureFlagResolverConfigurationProtocol.swift
@@ -9,11 +9,10 @@
 /// An object that provides the resources critical to functioning of the resolver.
 public protocol FeatureFlagResolverConfigurationProtocol {
     
-    /// An object that provides feature flag values used as a fallback, when the remote store is not available.
-    var localStore: FeatureFlagStoreProtocol { get }
-    
-    /// An object that provides feature flag values received from a remote server. This is the primary source of feature flag values.
-    var remoteStore: FeatureFlagStoreProtocol { get }
+    /// An array of stores which may contain feature flag values.
+    ///
+    /// + The stores are examined in order. The first value found for a key will be used.
+    var persistentStores: [FeatureFlagStoreProtocol] { get }
     
     /// An object that provides feature flag values used in the runtime, within a single app session.
     var runtimeStore: MutableFeatureFlagStoreProtocol { get }

--- a/Sources/YMFF/FeatureFlagResolverImplementation/Configuration/FeatureFlagResolverConfiguration.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/Configuration/FeatureFlagResolverConfiguration.swift
@@ -11,17 +11,14 @@
 /// A YMFF-supplied object used to provide the feature flag resolver with its configuration.
 public struct FeatureFlagResolverConfiguration {
     
-    public let localStore: FeatureFlagStoreProtocol
-    public let remoteStore: FeatureFlagStoreProtocol
+    public let persistentStores: [FeatureFlagStoreProtocol]
     public let runtimeStore: MutableFeatureFlagStoreProtocol
     
     public init(
-        localStore: FeatureFlagStore,
-        remoteStore: FeatureFlagStore,
+        persistentStores: [FeatureFlagStore],
         runtimeStore: MutableFeatureFlagStoreProtocol = RuntimeOverridesStore()
     ) {
-        self.localStore = localStore
-        self.remoteStore = remoteStore
+        self.persistentStores = persistentStores
         self.runtimeStore = runtimeStore
     }
     

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
@@ -68,7 +68,7 @@ extension FeatureFlagResolver {
     }
     
     func retrieveValue(forKey key: String, from store: FeatureFlagStoreProtocol) throws -> Any {
-        guard let value = store.value(forKey: key) else { throw FeatureFlagResolverError.valueNotFound }
+        guard let value = store.value(forKey: key) else { throw FeatureFlagResolverError.valueNotFoundInSpecificStore }
         return value
     }
     

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
@@ -33,11 +33,11 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
     
     public func overrideInRuntime<Value>(_ key: FeatureFlagKey, with newValue: Value) throws {
         try validateOverrideValue(newValue, forKey: key)
-        configuration.runtimeStore.setValue(newValue, forKey: key.localKey)
+        configuration.runtimeStore.setValue(newValue, forKey: key.remoteKey)
     }
     
     public func removeRuntimeOverride(for key: FeatureFlagKey) {
-        configuration.runtimeStore.removeValue(forKey: key.localKey)
+        configuration.runtimeStore.removeValue(forKey: key.remoteKey)
     }
     
 }
@@ -51,10 +51,10 @@ extension FeatureFlagResolver {
         let expectedType = Value.self
         let valueCandidate: Value
         
-        if let anyRuntimeValue = try? retrieveValue(forKey: key.localKey, from: configuration.runtimeStore) {
+        if let anyRuntimeValue = try? retrieveValue(forKey: key.remoteKey, from: configuration.runtimeStore) {
             anyValueCandidate = anyRuntimeValue
         } else {
-            let anyPersistentValue = try retrieveValueFromFirstStore(of: configuration.persistentStores, containingKey: key.localKey)
+            let anyPersistentValue = try retrieveValueFromFirstStore(of: configuration.persistentStores, containingKey: key.remoteKey)
             anyValueCandidate = anyPersistentValue
         }
         
@@ -104,7 +104,7 @@ extension FeatureFlagResolver {
     func validateOverrideValue<Value>(_ value: Value, forKey key: FeatureFlagKey) throws {
         try validateValue(value)
         
-        let anyPersistentValue = try? retrieveValueFromFirstStore(of: configuration.persistentStores, containingKey: key.localKey)
+        let anyPersistentValue = try? retrieveValueFromFirstStore(of: configuration.persistentStores, containingKey: key.remoteKey)
         
         if let anyPersistentValue = anyPersistentValue {
             _ = try cast(anyPersistentValue, to: Value.self)

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
@@ -71,6 +71,8 @@ extension FeatureFlagResolver {
     }
     
     func retrieveValueFromFirstStore(of stores: [FeatureFlagStoreProtocol], containingKey key: String) throws -> Any {
+        guard !stores.isEmpty else { throw FeatureFlagResolverError.persistentStoresIsEmpty }
+        
         for store in stores {
             if let value = store.value(forKey: key) {
                 return value

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolverError.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolverError.swift
@@ -8,7 +8,8 @@
 
 /// Errors returned by `FeatureFlagResolver`.
 public enum FeatureFlagResolverError: Error {
+    case noStoreContainsValueForKey
     case optionalValuesNotAllowed
     case typeMismatch
-    case valueNotFound
+    case valueNotFoundInSpecificStore
 }

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolverError.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolverError.swift
@@ -10,6 +10,7 @@
 public enum FeatureFlagResolverError: Error {
     case noStoreContainsValueForKey
     case optionalValuesNotAllowed
+    case persistentStoresIsEmpty
     case typeMismatch
     case valueNotFoundInSpecificStore
 }

--- a/Tests/YMFFTests/FeatureFlagKeyTests.swift
+++ b/Tests/YMFFTests/FeatureFlagKeyTests.swift
@@ -16,7 +16,6 @@ final class FeatureFlagKeyTests: XCTestCase {
         
         let featureFlagKey = FeatureFlagKey(keyString)
         
-        XCTAssertEqual(featureFlagKey.localKey, keyString)
         XCTAssertEqual(featureFlagKey.remoteKey, keyString)
     }
     

--- a/Tests/YMFFTests/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/FeatureFlagResolverTests.swift
@@ -161,6 +161,16 @@ extension FeatureFlagResolverTests {
         XCTAssertNoThrow(try resolver.retrieveValueFromFirstStore(of: resolver.configuration.persistentStores, containingKey: key))
     }
     
+    func testValueRetrievalFromEmptyPersistentStoresArray() {
+        resolver = FeatureFlagResolver(configuration: SharedAssets.configurationWithNoPersistentStores)
+        
+        let key = "int"
+        
+        do {
+            _ = try resolver.retrieveValueFromFirstStore(of: resolver.configuration.persistentStores, containingKey: key)
+        } catch FeatureFlagResolverError.persistentStoresIsEmpty { } catch { XCTFail() }
+    }
+    
     // MARK: Value Validation
     
     func testValueValidation() {

--- a/Tests/YMFFTests/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/FeatureFlagResolverTests.swift
@@ -88,7 +88,7 @@ extension FeatureFlagResolverTests {
         do {
             _ = try resolveNonexistentValue(for: SharedAssets.nonexistentKey)
             XCTFail()
-        } catch FeatureFlagResolverError.valueNotFound { } catch { XCTFail() }
+        } catch FeatureFlagResolverError.noStoreContainsValueForKey { } catch { XCTFail() }
     }
     
     private func resolveNonexistentValue(for key: FeatureFlagKey) throws -> Int {
@@ -157,15 +157,8 @@ extension FeatureFlagResolverTests {
     
     func testValueRetrieval() {
         let key = "int"
-        let localStore = resolver.configuration.localStore
-        let remoteStore = resolver.configuration.remoteStore
         
-        XCTAssertNoThrow(try resolver.retrieveValue(forKey: key, from: localStore))
-        
-        do {
-            _ = try resolver.retrieveValue(forKey: key, from: remoteStore)
-            XCTFail()
-        } catch FeatureFlagResolverError.valueNotFound { } catch { XCTFail() }
+        XCTAssertNoThrow(try resolver.retrieveValueFromFirstStore(of: resolver.configuration.persistentStores, containingKey: key))
     }
     
     // MARK: Value Validation

--- a/Tests/YMFFTests/FeatureFlagTests.swift
+++ b/Tests/YMFFTests/FeatureFlagTests.swift
@@ -15,19 +15,19 @@ final class FeatureFlagTests: XCTestCase {
     
     private static let resolver: FeatureFlagResolverProtocol = FeatureFlagResolver(configuration: SharedAssets.configuration)
     
-    @FeatureFlag(SharedAssets.boolKey.localKey, default: false, resolver: resolver)
+    @FeatureFlag(SharedAssets.boolKey.remoteKey, default: false, resolver: resolver)
     private var boolFeatureFlag
     
-    @FeatureFlag(SharedAssets.intKey.localKey, default: 999, resolver: resolver)
+    @FeatureFlag(SharedAssets.intKey.remoteKey, default: 999, resolver: resolver)
     private var intFeatureFlag
     
-    @FeatureFlag(SharedAssets.stringKey.localKey, default: "FALLBACK_STRING", resolver: resolver)
+    @FeatureFlag(SharedAssets.stringKey.remoteKey, default: "FALLBACK_STRING", resolver: resolver)
     private var stringFeatureFlag
     
-    @FeatureFlag(SharedAssets.optionalIntNonNilKey.localKey, default: 999, resolver: resolver)
+    @FeatureFlag(SharedAssets.optionalIntNonNilKey.remoteKey, default: 999, resolver: resolver)
     private var optionalIntFeatureFlag
     
-    @FeatureFlag(SharedAssets.nonexistentKey.localKey, default: 999, resolver: resolver)
+    @FeatureFlag(SharedAssets.nonexistentKey.remoteKey, default: 999, resolver: resolver)
     private var nonexistentIntFeatureFlag
     
     @FeatureFlag(SharedAssets.intToOverrideKey.remoteKey, default: 999, resolver: resolver)

--- a/Tests/YMFFTests/SharedAssets/SharedAssets.swift
+++ b/Tests/YMFFTests/SharedAssets/SharedAssets.swift
@@ -16,6 +16,10 @@ enum SharedAssets {
         .init(persistentStores: [.opaque(OpaqueStoreStab(store: remoteStore)), .transparent(localStore)])
     }
     
+    static var configurationWithNoPersistentStores: FeatureFlagResolverConfiguration {
+        .init(persistentStores: [])
+    }
+    
     private static var localStore: [String : Any] { [
         "bool": false,
         "int": 123,

--- a/Tests/YMFFTests/SharedAssets/SharedAssets.swift
+++ b/Tests/YMFFTests/SharedAssets/SharedAssets.swift
@@ -13,10 +13,7 @@ import YMFF
 enum SharedAssets {
     
     static var configuration: FeatureFlagResolverConfiguration {
-        .init(
-            localStore: .transparent(localStore),
-            remoteStore: .opaque(OpaqueStoreStab(store: remoteStore))
-        )
+        .init(persistentStores: [.opaque(OpaqueStoreStab(store: remoteStore)), .transparent(localStore)])
     }
     
     private static var localStore: [String : Any] { [


### PR DESCRIPTION
[Closes #12]

* Introduced a new approach to feature flag stores: instead of one local and one remote stores, a variable number of persistent stores can be specified
* The stores are examined in the order they were provided: the first one containing feature flag value for key will be used