### PR TITLE
v1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 /.build
-/docs/docsets/
 /.swiftpm
 /Packages
 /*.xcodeproj

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,0 +1,30 @@
+author: Yakov Manshin
+author_url: https://yakovmanshin.com/
+clean: true
+copyright: © 2020 [Yakov Manshin](https://yakovmanshin.com/). Available under [Apache License v2](https://github.com/yakovmanshin/YMFF/blob/main/LICENSE).
+custom_categories:
+    - name: FeatureFlag
+      children:
+          - FeatureFlag
+          - FeatureFlagKey
+    - name: Resolver
+      children:
+          - FeatureFlagResolverProtocol
+          - FeatureFlagResolver
+          - FeatureFlagResolverConfigurationProtocol
+          - FeatureFlagResolverConfiguration
+          - FeatureFlagResolverError
+    - name: Stores
+      children:
+          - FeatureFlagStoreProtocol
+          - MutableFeatureFlagStoreProtocol
+          - FeatureFlagStore
+          - TransparentFeatureFlagStore
+          - RuntimeOverridesStore
+disable_search: true
+github_file_prefix: https://github.com/yakovmanshin/YMFF/tree/master
+github_url: https://github.com/yakovmanshin/YMFF
+hide_documentation_coverage: true
+module: YMFF
+title: YMFF Docs
+undocumented_text: Documentation Coming Soon…

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ if FeatureFlags.promoEnabled {
 }
 ```
 
+### Overriding Values in Runtime
+
+YMFF lets you override feature flag values in runtime. One particular use case for changing values locally is when you need to test a particular feature covered with the feature flag, and you cannot or don’t want to modify the back-end configuration.
+
+**Runtime overrides work within a single session. Once you restart the app, the override values are erased.** 
+
+Overriding a feature flag value in runtime is as simple as assigning the new value to the flag.
+
+```swift
+FeatureFlags.promoEnabled = true
+```
+
+To remove the override and revert to using values from persistent stores, you can restart the app or call the `removeRuntimeOverride()` method on `FeatureFlag`’s *projected value* (i.e. the `FeatureFlag` instance itself, as opposed to its *wrapped value*).
+
+```swift
+// Here `FeatureFlags.$promoEnabled` has the type `FeatureFlag<Bool>`, 
+// while `FeatureFlags.promoEnabled` is of type `Bool`.
+FeatureFlags.$promoEnabled.removeRuntimeOverride()
+```
+
 You can browse the source files to learn more about the options available to you. An extended documentation is coming later.
 
 ## Contributing

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -12,7 +12,10 @@ final public class FeatureFlag<Value> {
     
     // MARK: Properties
     
+    /// The key used to retrieve feature flag values.
     public let key: FeatureFlagKey
+    
+    /// The fallback value returned when no store is able to provide the real one.
     public let defaultValue: Value
     
     private let resolver: FeatureFlagResolverProtocol
@@ -22,9 +25,9 @@ final public class FeatureFlag<Value> {
     /// Creates a new `FeatureFlag`.
     ///
     /// - Parameters:
-    ///   - key: *Required.* The string used to address feature flag values in both the local and remote stores.
-    ///   - defaultValue: *Required.* The value returned in case both the local and remote stores failed to provide values by the key.
-    ///   - resolver: *Required.* The resolver object used to retrieve values from the stores.
+    ///   - key: *Required.* The key used to address feature flag values in stores.
+    ///   - defaultValue: *Required.* The value returned in case all stores fail to provide a value.
+    ///   - resolver: *Required.* The resolver object used to retrieve values from stores.
     public init(
         _ key: FeatureFlagKey,
         default defaultValue: Value,
@@ -48,6 +51,7 @@ final public class FeatureFlag<Value> {
     
     // MARK: Projected Value
     
+    /// The object returned when referencing the feature flag with a dollar sign (`$`).
     public var projectedValue: FeatureFlag<Value> { self }
     
     // MARK: Runtime Overrides

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -12,8 +12,9 @@ final public class FeatureFlag<Value> {
     
     // MARK: Properties
     
-    private let key: FeatureFlagKey
-    private let defaultValue: Value
+    public let key: FeatureFlagKey
+    public let defaultValue: Value
+    
     private let resolver: FeatureFlagResolverProtocol
     
     // MARK: Initializers

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -49,4 +49,11 @@ final public class FeatureFlag<Value> {
     
     public var projectedValue: FeatureFlag<Value> { self }
     
+    // MARK: Runtime Overrides
+    
+    /// Removes the feature flag value that overrides persistent values in runtime.
+    public func removeRuntimeOverride() {
+        resolver.removeRuntimeOverride(for: key)
+    }
+    
 }

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -8,7 +8,7 @@
 
 /// An object that facilitates access to feature flag values.
 @propertyWrapper
-public struct FeatureFlag<Value> {
+final public class FeatureFlag<Value> {
     
     // MARK: Properties
     
@@ -44,5 +44,9 @@ public struct FeatureFlag<Value> {
             try? resolver.overrideInRuntime(key, with: newValue)
         }
     }
+    
+    // MARK: Projected Value
+    
+    public var projectedValue: FeatureFlag<Value> { self }
     
 }

--- a/Tests/YMFFTests/FeatureFlagTests.swift
+++ b/Tests/YMFFTests/FeatureFlagTests.swift
@@ -79,3 +79,33 @@ extension FeatureFlagTests {
     }
     
 }
+
+// MARK: - Projected Value Tests
+
+extension FeatureFlagTests {
+    
+    func testBoolProjectedValue() {
+        XCTAssertTrue(value($boolFeatureFlag, isOfType: FeatureFlag<Bool>.self))
+    }
+    
+    func testIntProjectedValue() {
+        XCTAssertTrue(value($intFeatureFlag, isOfType: FeatureFlag<Int>.self))
+    }
+    
+    func testStringProjectedValue() {
+        XCTAssertTrue(value($stringFeatureFlag, isOfType: FeatureFlag<String>.self))
+    }
+    
+    func testOptionalIntProjectedValue() {
+        XCTAssertTrue(value($optionalIntFeatureFlag, isOfType: FeatureFlag<Int?>.self))
+    }
+    
+    func testNonexistentIntProjectedValue() {
+        XCTAssertTrue(value($nonexistentIntFeatureFlag, isOfType: FeatureFlag<Int>.self))
+    }
+    
+    private func value<T>(_ value: Any, isOfType type: T.Type) -> Bool {
+        value is T
+    }
+    
+}

--- a/Tests/YMFFTests/FeatureFlagTests.swift
+++ b/Tests/YMFFTests/FeatureFlagTests.swift
@@ -68,6 +68,10 @@ extension FeatureFlagTests {
         overrideFlag = 789
         
         XCTAssertEqual(overrideFlag, 789)
+        
+        $overrideFlag.removeRuntimeOverride()
+        
+        XCTAssertEqual(overrideFlag, 456)
     }
     
     func testNonexistentWrappedValueOverride() {
@@ -76,6 +80,10 @@ extension FeatureFlagTests {
         nonexistentOverrideFlag = 789
         
         XCTAssertEqual(nonexistentOverrideFlag, 789)
+        
+        $nonexistentOverrideFlag.removeRuntimeOverride()
+        
+        XCTAssertEqual(nonexistentOverrideFlag, 999)
     }
     
 }

--- a/Tests/YMFFTests/XCTestManifests.swift
+++ b/Tests/YMFFTests/XCTestManifests.swift
@@ -28,11 +28,16 @@ extension FeatureFlagTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__FeatureFlagTests = [
+        ("testBoolProjectedValue", testBoolProjectedValue),
         ("testBoolWrappedValue", testBoolWrappedValue),
+        ("testIntProjectedValue", testIntProjectedValue),
         ("testIntWrappedValue", testIntWrappedValue),
+        ("testNonexistentIntProjectedValue", testNonexistentIntProjectedValue),
         ("testNonexistentIntWrappedValue", testNonexistentIntWrappedValue),
         ("testNonexistentWrappedValueOverride", testNonexistentWrappedValueOverride),
+        ("testOptionalIntProjectedValue", testOptionalIntProjectedValue),
         ("testOptionalIntValue", testOptionalIntValue),
+        ("testStringProjectedValue", testStringProjectedValue),
         ("testStringWrappedValue", testStringWrappedValue),
         ("testWrappedValueOverride", testWrappedValueOverride),
     ]


### PR DESCRIPTION
* [#27] Exposed projected value on `FeatureFlag` (#28)
* [#26] Facilitated removal of runtime overrides (#29)
* [#25] Updated `README` with documentation for runtime overriding (#30)
* Changed `FeatureFlag`’s `key` and `defaultValue` access mode to public