### PR TITLE
[#48] Override Value Validation Fix

### DIFF
--- a/Sources/YMFF/FeatureFlagResolver/Store/FeatureFlagStoreProtocol.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/FeatureFlagStoreProtocol.swift
@@ -9,6 +9,11 @@
 /// An object that stores feature flag values, and provides them at the resolver's request.
 public protocol FeatureFlagStoreProtocol {
     
+    /// Indicates whether the store contains a value that corresponds to the key.
+    ///
+    /// - Parameter key: *Required.* The key.
+    func containsValue(forKey key: String) -> Bool
+    
     /// Retrieves a feature flag value by its key.
     ///
     /// - Parameter key: *Required.* The key that points to a feature flag value in the store.

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
@@ -95,11 +95,13 @@ extension FeatureFlagResolver {
     func validateOverrideValue<Value>(_ value: Value, forKey key: FeatureFlagKey) throws {
         try validateValue(value)
         
-        
-        if let anyPersistentValue: Any = try retrieveFirstValueFoundInPersistentStores(byKey: key),
-           (anyPersistentValue as? Value) == nil
-        {
-            throw FeatureFlagResolverError.typeMismatch
+        do {
+            let _: Value = try retrieveFirstValueFoundInPersistentStores(byKey: key)
+        } catch FeatureFlagResolverError.valueNotFoundInPersistentStores {
+            // If none of the persistent stores contains a value for the key, then the client is attempting
+            // to set a new value (instead of overriding an existing one). That’s an acceptable use case.
+        } catch {
+            throw error
         }
     }
     

--- a/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/FeatureFlagResolver.swift
@@ -65,7 +65,10 @@ extension FeatureFlagResolver {
         }
         
         for store in stores {
-            if let value: Value = store.value(forKey: key) {
+            if store.containsValue(forKey: key) {
+                guard let value: Value = store.value(forKey: key)
+                else { throw FeatureFlagResolverError.typeMismatch }
+                
                 return value
             }
         }

--- a/Sources/YMFF/FeatureFlagResolverImplementation/Store/FeatureFlagStore.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/Store/FeatureFlagStore.swift
@@ -26,6 +26,19 @@ public enum FeatureFlagStore {
 
 extension FeatureFlagStore: FeatureFlagStoreProtocol {
     
+    public func containsValue(forKey key: String) -> Bool {
+        switch self {
+        case .opaque(let store):
+            return store.containsValue(forKey: key)
+        case .transparent(let store):
+            return store[key] != nil
+        #if canImport(Foundation)
+        case .userDefaults(let userDefaults):
+            return userDefaults.object(forKey: key) != nil
+        #endif
+        }
+    }
+    
     public func value<Value>(forKey key: String) -> Value? {
         switch self {
         case .opaque(let store):

--- a/Sources/YMFF/FeatureFlagResolverImplementation/Store/RuntimeOverridesStore.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/Store/RuntimeOverridesStore.swift
@@ -23,6 +23,10 @@ final public class RuntimeOverridesStore {
 
 extension RuntimeOverridesStore: MutableFeatureFlagStoreProtocol {
     
+    public func containsValue(forKey key: String) -> Bool {
+        store[key] != nil
+    }
+    
     public func value<Value>(forKey key: String) -> Value? {
         store[key] as? Value
     }

--- a/Sources/YMFF/FeatureFlagResolverImplementation/Store/UserDefaultsStore.swift
+++ b/Sources/YMFF/FeatureFlagResolverImplementation/Store/UserDefaultsStore.swift
@@ -31,6 +31,10 @@ final public class UserDefaultsStore {
 
 extension UserDefaultsStore: MutableFeatureFlagStoreProtocol {
     
+    public func containsValue(forKey key: String) -> Bool {
+        userDefaults.object(forKey: key) != nil
+    }
+    
     public func value<Value>(forKey key: String) -> Value? {
         userDefaults.value(forKey: key) as? Value
     }

--- a/Tests/YMFFTests/SharedAssets/SharedAssets.swift
+++ b/Tests/YMFFTests/SharedAssets/SharedAssets.swift
@@ -57,6 +57,10 @@ private struct OpaqueStoreWithLimitedTypeSupport: FeatureFlagStoreProtocol {
         self.store = store
     }
     
+    func containsValue(forKey key: String) -> Bool {
+        store[key] != nil
+    }
+    
     func value<Value>(forKey key: String) -> Value? {
         let expectedValueType = Value.self
         

--- a/Tests/YMFFTests/SharedAssets/SharedAssets.swift
+++ b/Tests/YMFFTests/SharedAssets/SharedAssets.swift
@@ -13,7 +13,10 @@ import YMFF
 enum SharedAssets {
     
     static var configuration: FeatureFlagResolverConfiguration {
-        .init(persistentStores: [.opaque(OpaqueStoreStab(store: remoteStore)), .transparent(localStore)])
+        .init(persistentStores: [
+            .opaque(OpaqueStoreWithLimitedTypeSupport(store: remoteStore)),
+            .transparent(localStore)
+        ])
     }
     
     static var configurationWithNoPersistentStores: FeatureFlagResolverConfiguration {
@@ -46,12 +49,28 @@ enum SharedAssets {
 
 // MARK: - Supplementary Types
 
-fileprivate struct OpaqueStoreStab: FeatureFlagStoreProtocol {
+private struct OpaqueStoreWithLimitedTypeSupport: FeatureFlagStoreProtocol {
     
-    let store: TransparentFeatureFlagStore
+    private let store: TransparentFeatureFlagStore
+    
+    init(store: TransparentFeatureFlagStore) {
+        self.store = store
+    }
     
     func value<Value>(forKey key: String) -> Value? {
-        store[key] as? Value
+        let expectedValueType = Value.self
+        
+        switch expectedValueType {
+        case is Bool.Type:
+            return store[key] as? Value
+        case is Int.Type:
+            return store[key] as? Value
+        case is String.Type:
+            return store[key] as? Value
+        default:
+            assertionFailure("The expected feature flag value type (\(expectedValueType)) is not supported")
+            return nil
+        }
     }
     
 }


### PR DESCRIPTION
[Closes #48]

* Fixed a bug that resulted in the override value validation logic always requesting values as `Optional<Any>`, which led to an error if the feature flag store supported a limited set of value types
* Extended `FeatureFlagStoreProtocol` with a new requirement, `containsValue(forKey:)`
* Implemented `containsValue(forKey:)` in `FeatureFlagStore`, `UserDefaultsStore`, and `RuntimeOverridesStore`
* Updated tests to cover more restrictive scenarios, including the one with limited number of supported feature flag value types