### PR TITLE
[#54] Updated Override Methods in FeatureFlagResolverProtocol

### DIFF
--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -60,7 +60,7 @@ final public class FeatureFlag<Value> {
     
     /// Removes the feature flag value that overrides persistent values in runtime.
     public func removeRuntimeOverride() {
-        resolver.removeRuntimeOverride(for: key)
+        try? resolver.removeValueFromMutableStore(using: key)
     }
     
 }

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -47,7 +47,7 @@ final public class FeatureFlag<Value> {
         get {
             (try? (resolver.value(for: key) as Value)) ?? defaultValue
         } set {
-            try? resolver.overrideInRuntime(key, with: newValue)
+            try? resolver.setValue(newValue, toMutableStoreUsing: key)
         }
     }
     

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -56,10 +56,12 @@ final public class FeatureFlag<Value> {
     /// The object returned when referencing the feature flag with a dollar sign (`$`).
     public var projectedValue: FeatureFlag<Value> { self }
     
-    // MARK: Runtime Overrides
+    // MARK: Mutable Value Removal
     
-    /// Removes the feature flag value that overrides persistent values in runtime.
-    public func removeRuntimeOverride() {
+    /// Removes the value from the first mutable feature flag store which contains one for `key`.
+    ///
+    /// + Errors thrown by `resolver` are ignored.
+    public func removeValueFromMutableStore() {
         try? resolver.removeValueFromMutableStore(using: key)
     }
     

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -42,10 +42,10 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         return retrievedValue
     }
     
-    public func overrideInRuntime<Value>(_ key: FeatureFlagKey, with newValue: Value) throws {
+    public func setValue<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) throws {
         try validateOverrideValue(newValue, forKey: key)
         
-        let mutableStore = try findFirstMutableStore()
+        let mutableStore = try findMutableStores()[0]
         mutableStore.setValue(newValue, forKey: key)
     }
     
@@ -104,11 +104,6 @@ extension FeatureFlagResolver {
         } catch {
             throw error
         }
-    }
-    
-    private func findFirstMutableStore() throws -> MutableFeatureFlagStoreProtocol {
-        let mutableStores = try findMutableStores()
-        return mutableStores[0]
     }
     
     private func firstMutableStore(withValueForKey key: String) throws -> MutableFeatureFlagStoreProtocol {

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -49,9 +49,9 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         mutableStore.setValue(newValue, forKey: key)
     }
     
-    public func removeRuntimeOverride(for key: FeatureFlagKey) {
-        let mutableStores = try? findMutableStores()
-        mutableStores?.forEach({ $0.removeValue(forKey: key) })
+    public func removeValueFromMutableStore(using key: FeatureFlagKey) throws {
+        let mutableStore = try firstMutableStore(withValueForKey: key)
+        mutableStore.removeValue(forKey: key)
     }
     
 }
@@ -109,6 +109,15 @@ extension FeatureFlagResolver {
     private func findFirstMutableStore() throws -> MutableFeatureFlagStoreProtocol {
         let mutableStores = try findMutableStores()
         return mutableStores[0]
+    }
+    
+    private func firstMutableStore(withValueForKey key: String) throws -> MutableFeatureFlagStoreProtocol {
+        let mutableStores = try findMutableStores()
+        
+        guard let firstStoreWithValueForKey = mutableStores.first(where: { $0.containsValue(forKey: key) }) else {
+            throw FeatureFlagResolverError.noMutableStoreContainsValueForKey(key: key)
+        }
+        return firstStoreWithValueForKey
     }
     
     private func findMutableStores() throws -> [MutableFeatureFlagStoreProtocol] {

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolverError.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolverError.swift
@@ -9,6 +9,7 @@
 /// Errors returned by `FeatureFlagResolver`.
 public enum FeatureFlagResolverError: Error {
     case noMutableStoreAvailable
+    case noMutableStoreContainsValueForKey(key: String)
     case noStoreAvailable
     case optionalValuesNotAllowed
     case typeMismatch

--- a/Sources/YMFFProtocols/FeatureFlagResolver/FeatureFlagResolverProtocol.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/FeatureFlagResolverProtocol.swift
@@ -24,9 +24,9 @@ public protocol FeatureFlagResolverProtocol {
     ///   - newValue: *Required.* The override value.
     func overrideInRuntime<Value>(_ key: FeatureFlagKey, with newValue: Value) throws
     
-    /// Removes an override value for the specified key, and reverts to the default resolution scheme.
+    /// Removes the value from the first mutable feature flag store which has one for the specified key.
     ///
     /// - Parameter key: *Required.* The feature flag key.
-    func removeRuntimeOverride(for key: FeatureFlagKey)
+    func removeValueFromMutableStore(using key: FeatureFlagKey) throws
     
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/FeatureFlagResolverProtocol.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/FeatureFlagResolverProtocol.swift
@@ -17,12 +17,12 @@ public protocol FeatureFlagResolverProtocol {
     /// - Parameter key: *Required.* The feature flag key.
     func value<Value>(for key: FeatureFlagKey) throws -> Value
     
-    /// Sets a new feature flag value that's available in runtime, within a single app session, and takes precedence over values from other stores.
+    /// Sets a new feature flag value to the first mutable store found in `configuration.stores`.
     ///
     /// - Parameters:
-    ///   - key: *Required.* The feature flag key.
     ///   - newValue: *Required.* The override value.
-    func overrideInRuntime<Value>(_ key: FeatureFlagKey, with newValue: Value) throws
+    ///   - key: *Required.* The feature flag key.
+    func setValue<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) throws
     
     /// Removes the value from the first mutable feature flag store which has one for the specified key.
     ///

--- a/Tests/YMFFTests/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/FeatureFlagResolverTests.swift
@@ -75,7 +75,7 @@ extension FeatureFlagResolverTests {
         
         XCTAssertEqual(try resolver.value(for: key), overrideValue)
         
-        resolver.removeRuntimeOverride(for: key)
+        XCTAssertNoThrow(try resolver.removeValueFromMutableStore(using: key))
         
         XCTAssertEqual(try resolver.value(for: key), originalValue)
     }

--- a/Tests/YMFFTests/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/FeatureFlagResolverTests.swift
@@ -71,7 +71,7 @@ extension FeatureFlagResolverTests {
         
         XCTAssertEqual(try resolver.value(for: key), originalValue)
         
-        XCTAssertNoThrow(try resolver.overrideInRuntime(key, with: overrideValue))
+        XCTAssertNoThrow(try resolver.setValue(overrideValue, toMutableStoreUsing: key))
         
         XCTAssertEqual(try resolver.value(for: key), overrideValue)
         
@@ -89,7 +89,7 @@ extension FeatureFlagResolverTests {
         XCTAssertEqual(try resolver.value(for: key), originalValue)
         
         do {
-            _ = try resolver.overrideInRuntime(key, with: overrideValue)
+            _ = try resolver.setValue(overrideValue, toMutableStoreUsing: key)
             XCTFail()
         } catch FeatureFlagResolverError.noMutableStoreAvailable { } catch { XCTFail() }
         
@@ -103,7 +103,7 @@ extension FeatureFlagResolverTests {
         XCTAssertEqual(try resolver.value(for: key), "STRING_VALUE_REMOTE")
         
         do {
-            _ = try resolver.overrideInRuntime(key, with: overrideValue)
+            _ = try resolver.setValue(overrideValue, toMutableStoreUsing: key)
             XCTFail()
         } catch FeatureFlagResolverError.typeMismatch { } catch { XCTFail() }
         
@@ -119,7 +119,7 @@ extension FeatureFlagResolverTests {
             XCTFail()
         } catch FeatureFlagResolverError.valueNotFoundInPersistentStores { } catch { XCTFail() }
         
-        XCTAssertNoThrow(try resolver.overrideInRuntime(key, with: overrideValue))
+        XCTAssertNoThrow(try resolver.setValue(overrideValue, toMutableStoreUsing: key))
         
         XCTAssertEqual(try resolver.value(for: key), overrideValue)
     }

--- a/Tests/YMFFTests/FeatureFlagTests.swift
+++ b/Tests/YMFFTests/FeatureFlagTests.swift
@@ -70,7 +70,7 @@ extension FeatureFlagTests {
         
         XCTAssertEqual(overrideFlag, 789)
         
-        $overrideFlag.removeRuntimeOverride()
+        $overrideFlag.removeValueFromMutableStore()
         
         XCTAssertEqual(overrideFlag, 456)
     }
@@ -82,7 +82,7 @@ extension FeatureFlagTests {
         
         XCTAssertEqual(nonexistentOverrideFlag, 789)
         
-        $nonexistentOverrideFlag.removeRuntimeOverride()
+        $nonexistentOverrideFlag.removeValueFromMutableStore()
         
         XCTAssertEqual(nonexistentOverrideFlag, 999)
     }

--- a/Tests/YMFFTests/MutableStoreTests.swift
+++ b/Tests/YMFFTests/MutableStoreTests.swift
@@ -55,7 +55,7 @@ final class MutableStoreTests: XCTestCase {
         XCTAssertEqual(overrideValueFromResolver, overrideValue)
         XCTAssertEqual(overrideValueFromStore, overrideValue)
         
-        resolver.removeRuntimeOverride(for: overrideKey)
+        XCTAssertNoThrow(try resolver.removeValueFromMutableStore(using: overrideKey))
         
         let removedValueFromResolver = try? resolver.value(for: overrideKey) as Int
         let removedValueFromStore: Int? = mutableStore.value(forKey: overrideKey)

--- a/Tests/YMFFTests/MutableStoreTests.swift
+++ b/Tests/YMFFTests/MutableStoreTests.swift
@@ -35,7 +35,7 @@ final class MutableStoreTests: XCTestCase {
         XCTAssertNil(initialValueFromResolver)
         XCTAssertNil(initialValueFromStore)
         
-        try? resolver.overrideInRuntime(overrideKey, with: overrideValue)
+        try? resolver.setValue(overrideValue, toMutableStoreUsing: overrideKey)
         let overrideValueFromResolver = try? resolver.value(for: overrideKey) as Int
         let overrideValueFromStore: Int? = mutableStore.value(forKey: overrideKey)
         

--- a/Tests/YMFFTests/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/UserDefaultsStoreTests.swift
@@ -45,7 +45,7 @@ extension UserDefaultsStoreTests {
         let key = "TEST_UserDefaults_key_456"
         let value = 456
         
-        try? resolver.overrideInRuntime(key, with: value)
+        try? resolver.setValue(value, toMutableStoreUsing: key)
         
         let retrievedValue = userDefaults.object(forKey: key) as? Int
         
@@ -56,7 +56,7 @@ extension UserDefaultsStoreTests {
         let key = "TEST_UserDefaults_key_789"
         let value = 789
         
-        try? resolver.overrideInRuntime(key, with: value)
+        try? resolver.setValue(value, toMutableStoreUsing: key)
         
         // FIXME: [#40] Can't use `retrievedValue: Int?` here
         let retrievedValue = try? resolver.value(for: key) as Int

--- a/Tests/YMFFTests/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/UserDefaultsStoreTests.swift
@@ -72,7 +72,7 @@ extension UserDefaultsStoreTests {
         
         XCTAssertEqual(userDefaults.object(forKey: key) as? Int, value)
         
-        resolver.removeRuntimeOverride(for: key)
+        XCTAssertNoThrow(try resolver.removeValueFromMutableStore(using: key))
         
         XCTAssertNil(userDefaults.object(forKey: key))
     }


### PR DESCRIPTION
[Closes #54]

* Replaced `FeatureFlagResolverProtocol`’s `overrideInRuntime(_:with:)` with `setValue(_:toMutableStoreUsing:)`
* Replaced `FeatureFlagResolverProtocol`’s `removeRuntimeOverride(for:)` with `removeValueFromMutableStore(using:)`; added `throw`ability
* Replaced `FeatureFlag `’s `removeRuntimeOverride()` with `removeValueFromMutableStore()`
* Updated tests