### PR TITLE
[#69] Protocol-Based Resolver Init

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint Podspec
-      run: pod lib lint --verbose
+      run: pod lib lint --allow-warnings --verbose

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -30,6 +30,10 @@ final public class FeatureFlagResolver {
         self.init(configuration: configuration as FeatureFlagResolverConfigurationProtocol)
     }
     
+    public convenience init(stores: [FeatureFlagStore]) {
+        self.init(configuration: FeatureFlagResolverConfiguration(stores: stores))
+    }
+    
     deinit {
         configuration.stores
             .compactMap({ $0.asMutable })

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -21,8 +21,13 @@ final public class FeatureFlagResolver {
     
     // MARK: Initializers
     
-    public init(configuration: FeatureFlagResolverConfiguration) {
+    public init(configuration: FeatureFlagResolverConfigurationProtocol) {
         self.configuration = configuration
+    }
+    
+    @available(*, deprecated, message: "Use init(stores:)")
+    public convenience init(configuration: FeatureFlagResolverConfiguration) {
+        self.init(configuration: configuration as FeatureFlagResolverConfigurationProtocol)
     }
     
     deinit {

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -21,6 +21,9 @@ final public class FeatureFlagResolver {
     
     // MARK: Initializers
     
+    /// Initializes the resolver with an object that conforms to `FeatureFlagResolverConfigurationProtocol`.
+    ///
+    /// - Parameter configuration: *Required.* The configuration used to read and write feature flag values.
     public init(configuration: FeatureFlagResolverConfigurationProtocol) {
         self.configuration = configuration
     }
@@ -30,6 +33,11 @@ final public class FeatureFlagResolver {
         self.init(configuration: configuration as FeatureFlagResolverConfigurationProtocol)
     }
     
+    /// Initializes the resolver with the list of feature flag stores.
+    ///
+    /// + Passing in an empty array will produce the `noStoreAvailable` error on next read attempt.
+    ///
+    /// - Parameter stores: *Required.* The array of feature flag stores.
     public convenience init(stores: [FeatureFlagStore]) {
         self.init(configuration: FeatureFlagResolverConfiguration(stores: stores))
     }

--- a/Tests/YMFFTests/MutableStoreTests.swift
+++ b/Tests/YMFFTests/MutableStoreTests.swift
@@ -72,7 +72,7 @@ final class MutableStoreTests: XCTestCase {
         mutableStore = MutableFeatureFlagStore(store: .init()) {
             saveChangesCount += 1
         }
-        resolver = FeatureFlagResolver(configuration: .init(stores: [.mutable(mutableStore)]))
+        resolver = FeatureFlagResolver(stores: [.mutable(mutableStore)])
         
         resolver = nil
         

--- a/Tests/YMFFTests/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/UserDefaultsStoreTests.swift
@@ -21,9 +21,9 @@ final class UserDefaultsStoreTests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        resolver = FeatureFlagResolver(configuration: .init(stores: [
+        resolver = FeatureFlagResolver(stores: [
             .mutable(UserDefaultsStore(userDefaults: userDefaults))
-        ]))
+        ])
     }
     
 }


### PR DESCRIPTION
[Closes #69]

* The designated initializer’s `configuration` parameter is now of type `FeatureFlagResolverConfigurationProtocol`
* Introduced `init(stores:)`, a replacement for the old `FeatureFlagResolverConfiguration`-based initializer
* Added a convenience initializer that accepts `FeatureFlagResolverConfiguration`; deprecated it in favor of `init(stores:)`
* Updated some tests to use `init(stores:)`
* Added documentation to the resolver’s initializer
* Added `--allow-warnings` to `cocoapods-podspec-lint`