### PR TITLE
[#68] Mutable Stores in Configuration

### DIFF
--- a/Sources/YMFF/FeatureFlagResolver/Configuration/MutableFeatureFlagResolverConfiguration.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Configuration/MutableFeatureFlagResolverConfiguration.swift
@@ -1,0 +1,28 @@
+//
+//  MutableFeatureFlagResolverConfiguration.swift
+//  YMFF
+//
+//  Created by Yakov Manshin on 5/17/21.
+//  Copyright © 2021 Yakov Manshin. See the LICENSE file for license info.
+//
+
+#if !COCOAPODS
+import YMFFProtocols
+#endif
+
+// MARK: - MutableFeatureFlagResolverConfiguration
+
+/// An object used to configure the resolver, which holds feature flag stores that can be changed.
+final public class MutableFeatureFlagResolverConfiguration {
+    
+    public var stores: [FeatureFlagStore]
+    
+    public init(stores: [FeatureFlagStore]) {
+        self.stores = stores
+    }
+    
+}
+
+// MARK: - FeatureFlagResolverConfigurationProtocol
+
+extension MutableFeatureFlagResolverConfiguration: FeatureFlagResolverConfigurationProtocol { }

--- a/Tests/YMFFTests/FeatureFlagResolverConfigurationTests.swift
+++ b/Tests/YMFFTests/FeatureFlagResolverConfigurationTests.swift
@@ -1,0 +1,35 @@
+//
+//  FeatureFlagResolverConfigurationTests.swift
+//  YMFF
+//
+//  Created by Yakov Manshin on 5/17/21.
+//  Copyright © 2021 Yakov Manshin. See the LICENSE file for license info.
+//
+
+import XCTest
+
+@testable import YMFF
+
+final class FeatureFlagResolverConfigurationTests: XCTestCase {
+    
+    func testStoreAdditionToMutableConfiguration() {
+        let configuration = MutableFeatureFlagResolverConfiguration(stores: [])
+        
+        XCTAssertEqual(configuration.stores.count, 0)
+        
+        configuration.stores.append(.immutable(TransparentFeatureFlagStore()))
+        
+        XCTAssertEqual(configuration.stores.count, 1)
+    }
+    
+    func testStoreRemovalFromMutableConfiguration() {
+        let configuration = MutableFeatureFlagResolverConfiguration(stores: [.immutable(TransparentFeatureFlagStore())])
+        
+        XCTAssertEqual(configuration.stores.count, 1)
+        
+        configuration.stores.removeAll()
+        
+        XCTAssertEqual(configuration.stores.count, 0)
+    }
+    
+}


### PR DESCRIPTION
[Closes #68]

* Introduced `MutableFeatureFlagResolverConfiguration`, a class that conforms to `FeatureFlagResolverConfigurationProtocol` and allows its `stores` property to be modified
* Added `FeatureFlagResolverConfigurationTests`