### PR TITLE
[#76] Disallowed Warnings on CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint Podspec
-      run: pod lib lint --allow-warnings --verbose
+      run: pod lib lint --verbose


### PR DESCRIPTION
[Closes #76]

* Removed `--allow-warnings` from `cocoapods-podspec-lint`