### PR TITLE
[#102] Testing with Older Compiler Versions

### DIFF
--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -16,14 +16,18 @@ jobs:
     - name: Select Xcode Version
       run: sudo xcode-select -switch ${{ env.XCODE_PATH }}
     - name: Run Tests
-      run: swift test -v
+      run: |
+        swift --version
+        swift test -v
   spm_tests_linux:
     name: SPM Tests (Linux)
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: Run Tests
-      run: swift test -v
+      run: |
+        swift --version
+        swift test -v
   cocoapods_podspec_lint:
     name: CocoaPods Podspec Linting
     runs-on: macOS-12

--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -10,11 +10,24 @@ env:
 jobs:
   spm_tests_macos:
     name: SPM Tests (macOS)
-    runs-on: macOS-12
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        SWIFT_VERSION: ["5.7", "5.5", "5.3"]
+        include:
+          - SWIFT_VERSION: "5.7"
+            OS: macOS-12
+            XCODE_APP_NAME: "Xcode_14.0.1"
+          - SWIFT_VERSION: "5.5"
+            OS: macOS-12
+            XCODE_APP_NAME: "Xcode_13.2.1"
+          - SWIFT_VERSION: "5.3"
+            OS: macOS-11
+            XCODE_APP_NAME: "Xcode_12.4"
     steps:
     - uses: actions/checkout@v3
     - name: Select Xcode Version
-      run: sudo xcode-select -switch ${{ env.XCODE_PATH }}
+      run: sudo xcode-select -switch "/Applications/${{ matrix.XCODE_APP_NAME }}.app"
     - name: Run Tests
       run: |
         swift --version

--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -9,7 +9,7 @@ env:
   XCODE_PATH: "/Applications/Xcode_14.0.1.app"
 jobs:
   spm_tests_macos:
-    name: SPM Tests (macOS)
+    name: SPM Tests (Swift ${{ matrix.SWIFT_VERSION }} on macOS)
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:


### PR DESCRIPTION
[Closes #102]

* Updated the `spm_tests_macos` job to test with Swift versions 5.7, 5.5, and 5.3
* Updated the `spm_tests_macos` and `spm_tests_linux` jobs to print the Swift version