### PR TITLE
[#81] Push to CocoaPods Trunk on Release

### DIFF
--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_call:
   workflow_dispatch:
 env:
   XCODE_PATH: "/Applications/Xcode_14.0.1.app"

--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "main"
   workflow_call:
+    inputs:
+      force_all_checks:
+        type: boolean
+        required: true
   workflow_dispatch:
 env:
   XCODE_PATH: "/Applications/Xcode_14.0.1.app"
@@ -45,7 +49,7 @@ jobs:
   cocoapods_podspec_lint:
     name: CocoaPods Podspec Linting
     runs-on: macOS-12
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ inputs.force_all_checks || github.event_name == 'pull_request' }}
     needs: [spm_tests_macos, spm_tests_linux]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -3,6 +3,8 @@ on:
   push:
   release:
     types: [published]
+env:
+  XCODE_PATH: "/Applications/Xcode_14.0.1.app"
 jobs:
   cocoapods_trunk_push:
     name: Push to CocoaPods Trunk
@@ -11,6 +13,8 @@ jobs:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
+    - name: Select Xcode Version
+      run: sudo xcode-select -switch ${{ env.XCODE_PATH }}
     - name: Push
       run: |
         pod trunk push YMFF.podspec --verbose

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,6 +1,5 @@
 name: Release
 on:
-  push:
   release:
     types: [published]
 env:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,0 +1,15 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  cocoapods_trunk_push:
+    name: Push to CocoaPods Trunk
+    runs-on: macOS-12
+    env:
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Push
+      run: |
+        pod trunk push YMFF.podspec --verbose

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -6,9 +6,12 @@ on:
 env:
   XCODE_PATH: "/Applications/Xcode_14.0.1.app"
 jobs:
+  run_common_checks:
+    uses: ./.github/workflows/Common.yml
   cocoapods_trunk_push:
     name: Push to CocoaPods Trunk
     runs-on: macOS-12
+    needs: run_common_checks
     env:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TOKEN }}
     steps:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  push:
   release:
     types: [published]
 jobs:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   run_common_checks:
     uses: ./.github/workflows/Common.yml
+    with:
+      force_all_checks: true
   cocoapods_trunk_push:
     name: Push to CocoaPods Trunk
     runs-on: macOS-12


### PR DESCRIPTION
[Closes #81]

* Introduced the `Release` GHA workflow
* Updated the `Common` workflow