### PR TITLE
[#104] Updated Minimum Swift Version to 5.5

### DIFF
--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        SWIFT_VERSION: ["5.7", "5.5", "5.3"]
+        SWIFT_VERSION: ["5.7", "5.5"]
         include:
           - SWIFT_VERSION: "5.7"
             OS: macOS-12
@@ -26,9 +26,6 @@ jobs:
           - SWIFT_VERSION: "5.5"
             OS: macOS-12
             XCODE_APP_NAME: "Xcode_13.2.1"
-          - SWIFT_VERSION: "5.3"
-            OS: macOS-11
-            XCODE_APP_NAME: "Xcode_12.4"
     steps:
     - uses: actions/checkout@v3
     - name: Select Xcode Version

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version: 5.5
 
 import PackageDescription
 

--- a/YMFF.podspec
+++ b/YMFF.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   
   s.name              = "YMFF"
   s.version           = "3.1.0"
-  s.swift_version     = "5.3"
+  s.swift_version     = "5.5"
   s.authors            = { "Yakov Manshin" => "git@yakovmanshin.com" }
   s.social_media_url  = "https://twitter.com/yakovmanshin"
   s.license           = { :type => "Apache License, version 2.0", :file => "LICENSE" }


### PR DESCRIPTION
[Closes #104]

* Updated the minimum Swift compiler version to 5.5
* Removed testing with Swift 5.3 from the GHA workflow