### PR TITLE
[#106] Updated Minimum Deployment Targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "YMFF",
     platforms: [
-        .iOS(.v11),
-        .macOS(.v10_13),
+        .iOS(.v13),
+        .macOS(.v10_15),
     ],
     products: [
         .library(

--- a/YMFF.podspec
+++ b/YMFF.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   
   # Platform
   
-  s.osx.deployment_target     = "10.13"
-  s.ios.deployment_target     = "11.0"
+  s.ios.deployment_target     = "13.0"
+  s.osx.deployment_target     = "10.15"
   
   # Subspecs
   


### PR DESCRIPTION
[Closes #106]

* Updated the minimum iOS deployment target to 13
* Updated the minimum macOS deployment target to 10.15 (Catalina)