### PR TITLE
[#135] Updated Minimum Swift Version to 5.8

### DIFF
--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        SWIFT_VERSION: ["5.10", "5.9", "5.8", "5.7", "5.5"]
+        SWIFT_VERSION: ["5.10", "5.9", "5.8"]
         include:
           - SWIFT_VERSION: "5.10"
             OS: macos-14
@@ -34,12 +34,6 @@ jobs:
           - SWIFT_VERSION: "5.8"
             OS: macos-13
             XCODE_APP_NAME: "Xcode_14.3.1"
-          - SWIFT_VERSION: "5.7"
-            OS: macOS-12
-            XCODE_APP_NAME: "Xcode_14.1"
-          - SWIFT_VERSION: "5.5"
-            OS: macOS-12
-            XCODE_APP_NAME: "Xcode_13.2.1"
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode Version

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.5
+// swift-tools-version: 5.8
 
 import PackageDescription
 

--- a/YMFF.podspec
+++ b/YMFF.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   
   s.name              = "YMFF"
   s.version           = "3.1.0"
-  s.swift_version     = "5.5"
+  s.swift_version     = "5.8"
   s.authors            = { "Yakov Manshin" => "git@yakovmanshin.com" }
   s.social_media_url  = "https://twitter.com/yakovmanshin"
   s.license           = { :type => "Apache License, version 2.0", :file => "LICENSE" }


### PR DESCRIPTION
[Closes #135]

* Updated the minimum Swift compiler version to 5.8
* Removed testing with Swift 5.5 and Swift 5.7 from the GHA workflow