### PR TITLE
[#131] Update All Mutable Stores When Setting or Removing Values

### DIFF
--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -264,35 +264,3 @@ extension FeatureFlagResolver {
     }
     
 }
-
-// MARK: - Overriding
-
-extension FeatureFlagResolver {
-    
-    private func validateOverrideValue<Value>(_ value: Value, forKey key: FeatureFlagKey) async throws {
-        try validateValue(value)
-        
-        do {
-            let _: Value = try await retrieveFirstValue(forKey: key)
-        } catch Error.valueNotFoundInStores {
-            // If none of the persistent stores contains a value for the key, then the client is attempting
-            // to set a new value (instead of overriding an existing one). That’s an acceptable use case.
-        } catch {
-            throw error
-        }
-    }
-    
-    func validateOverrideValueSync<Value>(_ value: Value, forKey key: FeatureFlagKey) throws {
-        try validateValue(value)
-        
-        do {
-            let _: Value = try retrieveFirstValueSync(forKey: key)
-        } catch Error.valueNotFoundInStores {
-            // If none of the persistent stores contains a value for the key, then the client is attempting
-            // to set a new value (instead of overriding an existing one). That’s an acceptable use case.
-        } catch {
-            throw error
-        }
-    }
-    
-}

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -97,10 +97,17 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
             throw Error.noStoreAvailable
         }
         
-        do {
-            try await mutableStores[0].removeValue(forKey: key)
-        } catch {
-            throw Error.storeError(error)
+        var lastErrorFromStore: (any Swift.Error)?
+        for store in mutableStores {
+            do {
+                try await store.removeValue(forKey: key)
+            } catch {
+                lastErrorFromStore = error
+            }
+        }
+        
+        if let lastErrorFromStore {
+            throw Error.storeError(lastErrorFromStore)
         }
     }
     
@@ -154,10 +161,17 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
             throw Error.noStoreAvailable
         }
         
-        do {
-            try syncMutableStores[0].removeValueSync(forKey: key)
-        } catch {
-            throw Error.storeError(error)
+        var lastErrorFromStore: (any Swift.Error)?
+        for store in syncMutableStores {
+            do {
+                try store.removeValueSync(forKey: key)
+            } catch {
+                lastErrorFromStore = error
+            }
+        }
+        
+        if let lastErrorFromStore {
+            throw Error.storeError(lastErrorFromStore)
         }
     }
     

--- a/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
@@ -576,16 +576,16 @@ final class FeatureFlagResolverTests: XCTestCase {
         let store3 = MutableFeatureFlagStoreMock()
         configuration.stores = [store1, store2, store3]
         store1.value_result = .failure(.valueNotFound)
-        store1.setValue_result = .failure(TestFeatureFlagStoreError.failedToSetValue)
+        store1.setValue_result = .failure(TestFeatureFlagStoreError.someError1)
         store2.valueSync_result = .success("TEST_value2")
         store2.setValueSync_result = .success(())
         store3.value_result = .success("TEST_value3")
-        store3.setValue_result = .failure(TestFeatureFlagStoreError.someError1)
+        store3.setValue_result = .failure(TestFeatureFlagStoreError.someError2)
         
         do {
             try await resolver.setValue("TEST_value4", toMutableStoreUsing: "TEST_key1")
             XCTFail("Expected an error")
-        } catch FeatureFlagResolver.Error.storeError(TestFeatureFlagStoreError.someError1) {
+        } catch FeatureFlagResolver.Error.storeError(TestFeatureFlagStoreError.someError2) {
             XCTAssertEqual(store1.value_invocationCount, 1)
             XCTAssertEqual(store1.value_keys, ["TEST_key1"])
             XCTAssertEqual(store2.valueSync_invocationCount, 1)
@@ -615,16 +615,16 @@ final class FeatureFlagResolverTests: XCTestCase {
         let store3 = SynchronousMutableFeatureFlagStoreMock()
         configuration.stores = [store1, store2, store3]
         store1.valueSync_result = .failure(.valueNotFound)
-        store1.setValueSync_result = .failure(TestFeatureFlagStoreError.failedToSetValue)
+        store1.setValueSync_result = .failure(TestFeatureFlagStoreError.someError1)
         store2.valueSync_result = .success("TEST_value2")
         store2.setValueSync_result = .success(())
         store3.valueSync_result = .success("TEST_value3")
-        store3.setValueSync_result = .failure(TestFeatureFlagStoreError.someError1)
+        store3.setValueSync_result = .failure(TestFeatureFlagStoreError.someError2)
         
         do {
             try resolver.setValueSync("TEST_value4", toMutableStoreUsing: "TEST_key1")
             XCTFail("Expected an error")
-        } catch FeatureFlagResolver.Error.storeError(TestFeatureFlagStoreError.someError1) {
+        } catch FeatureFlagResolver.Error.storeError(TestFeatureFlagStoreError.someError2) {
             XCTAssertEqual(store1.valueSync_invocationCount, 1)
             XCTAssertEqual(store1.valueSync_keys, ["TEST_key1"])
             XCTAssertEqual(store2.valueSync_invocationCount, 1)
@@ -828,14 +828,14 @@ final class FeatureFlagResolverTests: XCTestCase {
         let store1 = MutableFeatureFlagStoreMock()
         let store2 = SynchronousMutableFeatureFlagStoreMock()
         configuration.stores = [store1, store2]
-        store1.removeValue_result = .failure(.failedToRemoveValue)
+        store1.removeValue_result = .failure(.someError1)
         store2.removeValueSync_result = .success(())
         
         do {
             try await resolver.removeValueFromMutableStore(using: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(let error) {
-            XCTAssertEqual(error as? TestFeatureFlagStoreError, .failedToRemoveValue)
+            XCTAssertEqual(error as? TestFeatureFlagStoreError, .someError1)
             XCTAssertEqual(store1.removeValue_invocationCount, 1)
             XCTAssertEqual(store1.removeValue_keys, ["TEST_key1"])
             XCTAssertEqual(store2.removeValueSync_invocationCount, 1)
@@ -849,14 +849,14 @@ final class FeatureFlagResolverTests: XCTestCase {
         let store1 = SynchronousMutableFeatureFlagStoreMock()
         let store2 = SynchronousMutableFeatureFlagStoreMock()
         configuration.stores = [store1, store2]
-        store1.removeValueSync_result = .failure(.failedToRemoveValue)
+        store1.removeValueSync_result = .failure(.someError1)
         store2.removeValueSync_result = .success(())
         
         do {
             try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(let error) {
-            XCTAssertEqual(error as? TestFeatureFlagStoreError, .failedToRemoveValue)
+            XCTAssertEqual(error as? TestFeatureFlagStoreError, .someError1)
             XCTAssertEqual(store1.removeValueSync_invocationCount, 1)
             XCTAssertEqual(store1.removeValueSync_keys, ["TEST_key1"])
             XCTAssertEqual(store2.removeValueSync_invocationCount, 1)

--- a/Tests/YMFFTests/Utilities/TestFeatureFlagStoreError.swift
+++ b/Tests/YMFFTests/Utilities/TestFeatureFlagStoreError.swift
@@ -9,4 +9,5 @@
 enum TestFeatureFlagStoreError: Error, Equatable {
     case failedToSetValue
     case failedToRemoveValue
+    case someError1
 }

--- a/Tests/YMFFTests/Utilities/TestFeatureFlagStoreError.swift
+++ b/Tests/YMFFTests/Utilities/TestFeatureFlagStoreError.swift
@@ -7,7 +7,6 @@
 //
 
 enum TestFeatureFlagStoreError: Error, Equatable {
-    case failedToSetValue
-    case failedToRemoveValue
     case someError1
+    case someError2
 }


### PR DESCRIPTION
[Closes #131]

* Previously, only the first mutable store was updated when `FeatureFlagResolver` received a call to set or remove a value
* In this update, the behavior changes: Now all matching stores (i.e. mutable or synchronous mutable) are updated accordingly
* If one of the stores throws an error in the process, this error is caught and kept by the resolver; this is to avoid incomplete operations where an error in a single store prevents updates to the others
* After the remaining stores are updated; the last thrown error is re-thrown by the resolver