### PR TITLE
[#145] Code Cleanup for v4

### DIFF
--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -87,7 +87,7 @@ final public class FeatureFlag<RawValue, Value> {
     /// Removes the value from the first mutable feature flag store which contains one for `key`.
     ///
     /// + Errors thrown by `resolver` are ignored.
-    public func removeValueFromMutableStore() {
+    public func removeValueFromMutableStores() {
         try? resolver.removeValueSync(for: key)
     }
     

--- a/Sources/YMFF/FeatureFlag/FeatureFlag.swift
+++ b/Sources/YMFF/FeatureFlag/FeatureFlag.swift
@@ -73,7 +73,7 @@ final public class FeatureFlag<RawValue, Value> {
             
             return value
         } set {
-            try? resolver.setValueSync(transformer.rawValueFromValue(newValue), toMutableStoreUsing: key)
+            try? resolver.setValueSync(transformer.rawValueFromValue(newValue), for: key)
         }
     }
     
@@ -88,7 +88,7 @@ final public class FeatureFlag<RawValue, Value> {
     ///
     /// + Errors thrown by `resolver` are ignored.
     public func removeValueFromMutableStore() {
-        try? resolver.removeValueFromMutableStoreSync(using: key)
+        try? resolver.removeValueSync(for: key)
     }
     
 }

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver+Error.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver+Error.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2020 Yakov Manshin. See the LICENSE file for license info.
 //
 
+#if !COCOAPODS
+import YMFFProtocols
+#endif
+
 extension FeatureFlagResolver {
     
     /// Errors returned by `FeatureFlagResolver`.
@@ -18,7 +22,7 @@ extension FeatureFlagResolver {
         case noStoreAvailable
         
         /// No feature-flag store contains a value for the given key.
-        case valueNotFoundInStores(key: String)
+        case valueNotFoundInStores(key: FeatureFlagKey)
         
         /// The feature-flag store has thrown an error.
         case storeError(any Swift.Error)

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -34,7 +34,7 @@ final public class FeatureFlagResolver {
     ///
     /// - Parameter stores: *Required.* The array of feature flag stores.
     public convenience init(stores: [any FeatureFlagStore]) {
-        let configuration: any FeatureFlagResolverConfiguration = Configuration(stores: stores)
+        let configuration = Configuration(stores: stores)
         self.init(configuration: configuration)
     }
     

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -57,7 +57,7 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         try await retrieveFirstValue(forKey: key)
     }
     
-    public func setValue<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) async throws {
+    public func setValue<Value>(_ value: Value, for key: FeatureFlagKey) async throws {
         let mutableStores = getMutableStores()
         guard !mutableStores.isEmpty else {
             throw Error.noStoreAvailable
@@ -75,7 +75,7 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         var lastErrorFromStore: (any Swift.Error)?
         for store in mutableStores {
             do {
-                try await store.setValue(newValue, for: key)
+                try await store.setValue(value, for: key)
             } catch {
                 lastErrorFromStore = error
             }
@@ -86,7 +86,7 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         }
     }
     
-    public func removeValueFromMutableStore(using key: FeatureFlagKey) async throws {
+    public func removeValue(for key: FeatureFlagKey) async throws {
         let mutableStores = getMutableStores()
         guard !mutableStores.isEmpty else {
             throw Error.noStoreAvailable
@@ -116,7 +116,7 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
         try retrieveFirstValueSync(forKey: key)
     }
     
-    public func setValueSync<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) throws {
+    public func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws {
         let syncMutableStores = getSyncMutableStores()
         guard !syncMutableStores.isEmpty else {
             throw Error.noStoreAvailable
@@ -134,7 +134,7 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
         var lastErrorFromStore: (any Swift.Error)?
         for store in syncMutableStores {
             do {
-                try store.setValueSync(newValue, for: key)
+                try store.setValueSync(value, for: key)
             } catch {
                 lastErrorFromStore = error
             }
@@ -145,7 +145,7 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
         }
     }
     
-    public func removeValueFromMutableStoreSync(using key: FeatureFlagKey) throws {
+    public func removeValueSync(for key: FeatureFlagKey) throws {
         let syncMutableStores = getSyncMutableStores()
         guard !syncMutableStores.isEmpty else {
             throw Error.noStoreAvailable

--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -65,7 +65,7 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         
         for store in getStores() {
             if
-                case .failure(let error) = await store.value(forKey: key) as Result<Value, _>,
+                case .failure(let error) = await store.value(for: key) as Result<Value, _>,
                 case .typeMismatch = error
             {
                 throw Error.storeError(error)
@@ -75,7 +75,7 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         var lastErrorFromStore: (any Swift.Error)?
         for store in mutableStores {
             do {
-                try await store.setValue(newValue, forKey: key)
+                try await store.setValue(newValue, for: key)
             } catch {
                 lastErrorFromStore = error
             }
@@ -95,7 +95,7 @@ extension FeatureFlagResolver: FeatureFlagResolverProtocol {
         var lastErrorFromStore: (any Swift.Error)?
         for store in mutableStores {
             do {
-                try await store.removeValue(forKey: key)
+                try await store.removeValue(for: key)
             } catch {
                 lastErrorFromStore = error
             }
@@ -124,7 +124,7 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
         
         for store in getSyncStores() {
             if
-                case .failure(let error) = store.valueSync(forKey: key) as Result<Value, _>,
+                case .failure(let error) = store.valueSync(for: key) as Result<Value, _>,
                 case .typeMismatch = error
             {
                 throw Error.storeError(error)
@@ -134,7 +134,7 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
         var lastErrorFromStore: (any Swift.Error)?
         for store in syncMutableStores {
             do {
-                try store.setValueSync(newValue, forKey: key)
+                try store.setValueSync(newValue, for: key)
             } catch {
                 lastErrorFromStore = error
             }
@@ -154,7 +154,7 @@ extension FeatureFlagResolver: SynchronousFeatureFlagResolverProtocol {
         var lastErrorFromStore: (any Swift.Error)?
         for store in syncMutableStores {
             do {
-                try store.removeValueSync(forKey: key)
+                try store.removeValueSync(for: key)
             } catch {
                 lastErrorFromStore = error
             }
@@ -200,7 +200,7 @@ extension FeatureFlagResolver {
         }
         
         for store in matchingStores {
-            switch await store.value(forKey: key) as Result<Value, _> {
+            switch await store.value(for: key) as Result<Value, _> {
             case .success(let value):
                 return value
             case .failure(let error):
@@ -225,7 +225,7 @@ extension FeatureFlagResolver {
         }
         
         for store in matchingStores {
-            switch store.valueSync(forKey: key) as Result<Value, _> {
+            switch store.valueSync(for: key) as Result<Value, _> {
             case .success(let value):
                 return value
             case .failure(let error):

--- a/Sources/YMFF/FeatureFlagResolver/Store/RuntimeOverridesStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/RuntimeOverridesStore.swift
@@ -27,17 +27,17 @@ final public class RuntimeOverridesStore {
 
 extension RuntimeOverridesStore: SynchronousMutableFeatureFlagStore {
     
-    public func valueSync<Value>(forKey key: String) -> Result<Value, FeatureFlagStoreError> {
+    public func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
         guard let anyValue = store[key] else { return .failure(.valueNotFound) }
         guard let value = anyValue as? Value else { return .failure(.typeMismatch) }
         return .success(value)
     }
     
-    public func setValueSync<Value>(_ value: Value, forKey key: String) {
+    public func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) {
         store[key] = value
     }
     
-    public func removeValueSync(forKey key: String) {
+    public func removeValueSync(for key: FeatureFlagKey) {
         store.removeValue(forKey: key)
     }
     

--- a/Sources/YMFF/FeatureFlagResolver/Store/TransparentFeatureFlagStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/TransparentFeatureFlagStore.swift
@@ -19,7 +19,7 @@ public typealias TransparentFeatureFlagStore = [String: Any]
 
 extension TransparentFeatureFlagStore: SynchronousFeatureFlagStore, FeatureFlagStore {
     
-    public func valueSync<V>(forKey key: String) -> Result<V, FeatureFlagStoreError> {
+    public func valueSync<V>(for key: FeatureFlagKey) -> Result<V, FeatureFlagStoreError> {
         guard let anyValue = self[key] else { return .failure(.valueNotFound) }
         guard let value = anyValue as? V else { return .failure(.typeMismatch) }
         return .success(value)

--- a/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
@@ -34,17 +34,17 @@ final public class UserDefaultsStore {
 
 extension UserDefaultsStore: SynchronousMutableFeatureFlagStore {
     
-    public func valueSync<Value>(forKey key: String) -> Result<Value, FeatureFlagStoreError> {
+    public func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
         guard let anyValue = userDefaults.object(forKey: key) else { return .failure(.valueNotFound) }
         guard let value = anyValue as? Value else { return .failure(.typeMismatch) }
         return .success(value)
     }
     
-    public func setValueSync<Value>(_ value: Value, forKey key: String) {
+    public func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) {
         userDefaults.set(value, forKey: key)
     }
     
-    public func removeValueSync(forKey key: String) {
+    public func removeValueSync(for key: FeatureFlagKey) {
         userDefaults.removeObject(forKey: key)
     }
     

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Resolver/FeatureFlagResolverProtocol.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Resolver/FeatureFlagResolverProtocol.swift
@@ -19,11 +19,11 @@ public protocol FeatureFlagResolverProtocol {
     /// - Parameters:
     ///   - newValue: *Required.* The override value.
     ///   - key: *Required.* The feature flag key.
-    func setValue<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) async throws
+    func setValue<Value>(_ value: Value, for key: FeatureFlagKey) async throws
     
     /// Removes the value from the first mutable feature flag store which has one for the specified key.
     ///
     /// - Parameter key: *Required.* The feature flag key.
-    func removeValueFromMutableStore(using key: FeatureFlagKey) async throws
+    func removeValue(for key: FeatureFlagKey) async throws
     
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Resolver/FeatureFlagResolverProtocol.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Resolver/FeatureFlagResolverProtocol.swift
@@ -9,9 +9,6 @@
 /// A service that resolves feature flag values with their keys.
 public protocol FeatureFlagResolverProtocol {
     
-    /// The object used to configure the resolver.
-    var configuration: FeatureFlagResolverConfiguration { get }
-    
     /// Returns a value for the specified key.
     ///
     /// - Parameter key: *Required.* The feature flag key.

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Resolver/SynchronousFeatureFlagResolverProtocol.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Resolver/SynchronousFeatureFlagResolverProtocol.swift
@@ -18,12 +18,12 @@ public protocol SynchronousFeatureFlagResolverProtocol: FeatureFlagResolverProto
     /// - Parameters:
     ///   - newValue: *Required.* The override value.
     ///   - key: *Required.* The feature flag key.
-    func setValueSync<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) throws
+    func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws
     
     /// Removes the value from the first mutable feature flag store which has one for the specified key.
     ///
     /// - Parameter key: *Required.* The feature flag key.
-    func removeValueFromMutableStoreSync(using key: FeatureFlagKey) throws
+    func removeValueSync(for key: FeatureFlagKey) throws
     
 }
 
@@ -35,12 +35,12 @@ extension SynchronousFeatureFlagResolverProtocol {
         try valueSync(for: key)
     }
     
-    public func setValue<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) async throws {
-        try setValueSync(newValue, toMutableStoreUsing: key)
+    public func setValue<Value>(_ newValue: Value, for key: FeatureFlagKey) async throws {
+        try setValueSync(newValue, for: key)
     }
     
-    public func removeValueFromMutableStore(using key: FeatureFlagKey) async throws {
-        try removeValueFromMutableStoreSync(using: key)
+    public func removeValue(for key: FeatureFlagKey) async throws {
+        try removeValueSync(for: key)
     }
     
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Store/FeatureFlagStore.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Store/FeatureFlagStore.swift
@@ -12,6 +12,6 @@ public protocol FeatureFlagStore {
     /// Retrieves a feature flag value by its key.
     ///
     /// - Parameter key: *Required.* The key that points to a feature flag value in the store.
-    func value<Value>(forKey key: String) async -> Result<Value, FeatureFlagStoreError>
+    func value<Value>(for key: FeatureFlagKey) async -> Result<Value, FeatureFlagStoreError>
     
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Store/MutableFeatureFlagStore.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Store/MutableFeatureFlagStore.swift
@@ -14,12 +14,12 @@ public protocol MutableFeatureFlagStore: AnyObject, FeatureFlagStore {
     /// - Parameters:
     ///   - value: *Required.* The value to record.
     ///   - key: *Required.* The key used to address the value.
-    func setValue<Value>(_ value: Value, forKey key: String) async throws
+    func setValue<Value>(_ value: Value, for key: FeatureFlagKey) async throws
     
     /// Removes the value from the store.
     ///
     /// - Parameter key: *Required.* The key used to address the value.
-    func removeValue(forKey key: String) async throws
+    func removeValue(for key: FeatureFlagKey) async throws
     
     /// Immediately saves changed values so they’re not lost.
     ///

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Store/SynchronousFeatureFlagStore.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Store/SynchronousFeatureFlagStore.swift
@@ -11,7 +11,7 @@ public protocol SynchronousFeatureFlagStore: FeatureFlagStore {
     /// Retrieves a feature flag value by its key.
     ///
     /// - Parameter key: *Required.* The key that points to a feature flag value in the store.
-    func valueSync<Value>(forKey key: String) -> Result<Value, FeatureFlagStoreError>
+    func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError>
     
 }
 
@@ -19,8 +19,8 @@ public protocol SynchronousFeatureFlagStore: FeatureFlagStore {
 
 extension SynchronousFeatureFlagStore {
     
-    public func value<Value>(forKey key: String) async -> Result<Value, FeatureFlagStoreError> {
-        valueSync(forKey: key)
+    public func value<Value>(for key: FeatureFlagKey) async -> Result<Value, FeatureFlagStoreError> {
+        valueSync(for: key)
     }
     
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Store/SynchronousMutableFeatureFlagStore.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Store/SynchronousMutableFeatureFlagStore.swift
@@ -13,12 +13,12 @@ public protocol SynchronousMutableFeatureFlagStore: SynchronousFeatureFlagStore,
     /// - Parameters:
     ///   - value: *Required.* The value to record.
     ///   - key: *Required.* The key used to address the value.
-    func setValueSync<Value>(_ value: Value, forKey key: String) throws
+    func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws
     
     /// Removes the value from the store.
     ///
     /// - Parameter key: *Required.* The key used to address the value.
-    func removeValueSync(forKey key: String) throws
+    func removeValueSync(for key: FeatureFlagKey) throws
     
     /// Immediately saves changed values so they’re not lost.
     ///
@@ -31,12 +31,12 @@ public protocol SynchronousMutableFeatureFlagStore: SynchronousFeatureFlagStore,
 
 extension SynchronousMutableFeatureFlagStore {
     
-    public func setValue<Value>(_ value: Value, forKey key: String) async throws {
-        try setValueSync(value, forKey: key)
+    public func setValue<Value>(_ value: Value, for key: FeatureFlagKey) async throws {
+        try setValueSync(value, for: key)
     }
     
-    public func removeValue(forKey key: String) async throws {
-        try removeValueSync(forKey: key)
+    public func removeValue(for key: FeatureFlagKey) async throws {
+        try removeValueSync(for: key)
     }
     
     public func saveChanges() async throws {

--- a/Tests/YMFFTests/Cases/FeatureFlagResolverConfigurationTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagResolverConfigurationTests.swift
@@ -1,6 +1,6 @@
 //
 //  FeatureFlagResolverConfigurationTests.swift
-//  YMFF
+//  YMFFTests
 //
 //  Created by Yakov Manshin on 5/17/21.
 //  Copyright © 2021 Yakov Manshin. See the LICENSE file for license info.

--- a/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
@@ -1,6 +1,6 @@
 //
 //  FeatureFlagResolverTests.swift
-//  YMFF
+//  YMFFTests
 //
 //  Created by Yakov Manshin on 9/24/20.
 //  Copyright © 2020 Yakov Manshin. See the LICENSE file for license info.

--- a/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
@@ -350,7 +350,7 @@ final class FeatureFlagResolverTests: XCTestCase {
     
     func test_setValue_noStores() async {
         do {
-            try await resolver.setValue(123, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(123, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -359,7 +359,7 @@ final class FeatureFlagResolverTests: XCTestCase {
     
     func test_setValueSync_noStores() {
         do {
-            try resolver.setValueSync(123, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(123, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -371,7 +371,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try resolver.setValueSync(123, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(123, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -383,7 +383,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try await resolver.setValue(123, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(123, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -395,7 +395,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try resolver.setValueSync(123, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(123, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -408,7 +408,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store.value_result = .failure(.valueNotFound)
         
         do {
-            try await resolver.setValue("TEST_value1", toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue("TEST_value1", for: "TEST_key1")
             
             XCTAssertEqual(store.value_invocationCount, 1)
             XCTAssertEqual(store.value_keys, ["TEST_key1"])
@@ -427,7 +427,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store.valueSync_result = .failure(.valueNotFound)
         
         do {
-            try resolver.setValueSync("TEST_value1", toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync("TEST_value1", for: "TEST_key1")
             
             XCTAssertEqual(store.valueSync_invocationCount, 1)
             XCTAssertEqual(store.valueSync_keys, ["TEST_key1"])
@@ -446,7 +446,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store.value_result = .success("TEST_value1")
         
         do {
-            try await resolver.setValue("TEST_value2", toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue("TEST_value2", for: "TEST_key1")
             
             XCTAssertEqual(store.value_invocationCount, 1)
             XCTAssertEqual(store.value_keys, ["TEST_key1"])
@@ -465,7 +465,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store.valueSync_result = .success("TEST_value1")
         
         do {
-            try resolver.setValueSync("TEST_value2", toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync("TEST_value2", for: "TEST_key1")
             
             XCTAssertEqual(store.valueSync_invocationCount, 1)
             XCTAssertEqual(store.valueSync_keys, ["TEST_key1"])
@@ -486,7 +486,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = 456
-            try await resolver.setValue(newValue, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.value_invocationCount, 1)
             XCTAssertEqual(store.value_keys, ["TEST_key1"])
@@ -507,7 +507,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = 456
-            try resolver.setValueSync(newValue, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.valueSync_invocationCount, 1)
             XCTAssertEqual(store.valueSync_keys, ["TEST_key1"])
@@ -528,7 +528,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = nil
-            try await resolver.setValue(newValue, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.value_invocationCount, 1)
             XCTAssertEqual(store.value_keys, ["TEST_key1"])
@@ -549,7 +549,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = nil
-            try resolver.setValueSync(newValue, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.valueSync_invocationCount, 1)
             XCTAssertEqual(store.valueSync_keys, ["TEST_key1"])
@@ -570,7 +570,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = 456
-            try await resolver.setValue(newValue, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.value_invocationCount, 1)
             XCTAssertEqual(store.value_keys, ["TEST_key1"])
@@ -591,7 +591,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = 456
-            try resolver.setValueSync(newValue, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.valueSync_invocationCount, 1)
             XCTAssertEqual(store.valueSync_keys, ["TEST_key1"])
@@ -612,7 +612,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = nil
-            try await resolver.setValue(newValue, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.value_invocationCount, 1)
             XCTAssertEqual(store.value_keys, ["TEST_key1"])
@@ -633,7 +633,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         
         do {
             let newValue: Int? = nil
-            try resolver.setValueSync(newValue, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(newValue, for: "TEST_key1")
             
             XCTAssertEqual(store.valueSync_invocationCount, 1)
             XCTAssertEqual(store.valueSync_keys, ["TEST_key1"])
@@ -652,7 +652,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store.value_result = .success("TEST_value1")
         
         do {
-            try await resolver.setValue(456, toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue(456, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(FeatureFlagStoreError.typeMismatch) {
             XCTAssertEqual(store.value_invocationCount, 1)
@@ -670,7 +670,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store.valueSync_result = .success("TEST_value1")
         
         do {
-            try resolver.setValueSync(456, toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync(456, for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(FeatureFlagStoreError.typeMismatch) {
             XCTAssertEqual(store.valueSync_invocationCount, 1)
@@ -692,7 +692,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store3.valueSync_result = .success("TEST_value3")
         
         do {
-            try await resolver.setValue("TEST_value4", toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue("TEST_value4", for: "TEST_key1")
             
             XCTAssertEqual(store1.value_invocationCount, 1)
             XCTAssertEqual(store1.value_keys, ["TEST_key1"])
@@ -723,7 +723,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store3.valueSync_result = .success("TEST_value3")
         
         do {
-            try resolver.setValueSync("TEST_value4", toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync("TEST_value4", for: "TEST_key1")
             
             XCTAssertEqual(store1.value_invocationCount, 0)
             XCTAssertTrue(store1.value_keys.isEmpty)
@@ -755,7 +755,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store3.setValue_result = .failure(TestFeatureFlagStoreError.someError2)
         
         do {
-            try await resolver.setValue("TEST_value4", toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue("TEST_value4", for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(TestFeatureFlagStoreError.someError2) {
             XCTAssertEqual(store1.value_invocationCount, 1)
@@ -794,7 +794,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store3.setValueSync_result = .failure(TestFeatureFlagStoreError.someError2)
         
         do {
-            try resolver.setValueSync("TEST_value4", toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync("TEST_value4", for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(TestFeatureFlagStoreError.someError2) {
             XCTAssertEqual(store1.valueSync_invocationCount, 1)
@@ -830,7 +830,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store3.valueSync_result = .success("TEST_value3")
         
         do {
-            try await resolver.setValue("TEST_value4", toMutableStoreUsing: "TEST_key1")
+            try await resolver.setValue("TEST_value4", for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(FeatureFlagStoreError.typeMismatch) {
             XCTAssertEqual(store1.value_invocationCount, 1)
@@ -858,7 +858,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store3.valueSync_result = .success("TEST_value3")
         
         do {
-            try resolver.setValueSync("TEST_value4", toMutableStoreUsing: "TEST_key1")
+            try resolver.setValueSync("TEST_value4", for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(FeatureFlagStoreError.typeMismatch) {
             XCTAssertEqual(store1.valueSync_invocationCount, 1)
@@ -878,7 +878,7 @@ final class FeatureFlagResolverTests: XCTestCase {
     
     func test_removeValueFromMutableStore_noStores() async {
         do {
-            try await resolver.removeValueFromMutableStore(using: "TEST_key1")
+            try await resolver.removeValue(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -887,7 +887,7 @@ final class FeatureFlagResolverTests: XCTestCase {
     
     func test_removeValueFromMutableStoreSync_noStores() {
         do {
-            try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
+            try resolver.removeValueSync(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -899,7 +899,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
+            try resolver.removeValueSync(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -911,7 +911,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try await resolver.removeValueFromMutableStore(using: "TEST_key1")
+            try await resolver.removeValue(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -923,7 +923,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
+            try resolver.removeValueSync(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.noStoreAvailable { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -935,7 +935,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try await resolver.removeValueFromMutableStore(using: "TEST_key1")
+            try await resolver.removeValue(for: "TEST_key1")
             
             XCTAssertEqual(store.removeValue_invocationCount, 1)
             XCTAssertEqual(store.removeValue_keys, ["TEST_key1"])
@@ -949,7 +949,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store]
         
         do {
-            try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
+            try resolver.removeValueSync(for: "TEST_key1")
             
             XCTAssertEqual(store.removeValueSync_invocationCount, 1)
             XCTAssertEqual(store.removeValueSync_keys, ["TEST_key1"])
@@ -965,7 +965,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store1, store2, store3]
         
         do {
-            try await resolver.removeValueFromMutableStore(using: "TEST_key1")
+            try await resolver.removeValue(for: "TEST_key1")
             
             XCTAssertEqual(store1.removeValue_invocationCount, 1)
             XCTAssertEqual(store1.removeValue_keys, ["TEST_key1"])
@@ -983,7 +983,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         configuration.stores = [store1, store2, store3]
         
         do {
-            try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
+            try resolver.removeValueSync(for: "TEST_key1")
             
             XCTAssertEqual(store1.removeValueSync_invocationCount, 1)
             XCTAssertEqual(store1.removeValueSync_keys, ["TEST_key1"])
@@ -1004,7 +1004,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store2.removeValueSync_result = .success(())
         
         do {
-            try await resolver.removeValueFromMutableStore(using: "TEST_key1")
+            try await resolver.removeValue(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(let error) {
             XCTAssertEqual(error as? TestFeatureFlagStoreError, .someError1)
@@ -1025,7 +1025,7 @@ final class FeatureFlagResolverTests: XCTestCase {
         store2.removeValueSync_result = .success(())
         
         do {
-            try resolver.removeValueFromMutableStoreSync(using: "TEST_key1")
+            try resolver.removeValueSync(for: "TEST_key1")
             XCTFail("Expected an error")
         } catch FeatureFlagResolver.Error.storeError(let error) {
             XCTAssertEqual(error as? TestFeatureFlagStoreError, .someError1)

--- a/Tests/YMFFTests/Cases/FeatureFlagTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagTests.swift
@@ -1,6 +1,6 @@
 //
 //  FeatureFlagTests.swift
-//  YMFF
+//  YMFFTests
 //
 //  Created by Yakov Manshin on 9/26/20.
 //  Copyright © 2020 Yakov Manshin. See the LICENSE file for license info.

--- a/Tests/YMFFTests/Cases/FeatureFlagTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagTests.swift
@@ -133,7 +133,7 @@ final class FeatureFlagTests: XCTestCase {
         
         resolver.removeValueFromMutableStoreSync_result = .success(())
         
-        $stringFeatureFlag.removeValueFromMutableStore()
+        $stringFeatureFlag.removeValueFromMutableStores()
         
         XCTAssertEqual(resolver.removeValueFromMutableStoreSync_invocationCount, 1)
         XCTAssertEqual(resolver.removeValueFromMutableStoreSync_keys, ["TEST_string_key"])
@@ -145,7 +145,7 @@ final class FeatureFlagTests: XCTestCase {
         
         resolver.removeValueFromMutableStoreSync_result = .failure(SomeError())
         
-        $stringFeatureFlag.removeValueFromMutableStore()
+        $stringFeatureFlag.removeValueFromMutableStores()
         
         XCTAssertEqual(resolver.removeValueFromMutableStoreSync_invocationCount, 1)
         XCTAssertEqual(resolver.removeValueFromMutableStoreSync_keys, ["TEST_string_key"])

--- a/Tests/YMFFTests/Cases/RuntimeOverridesStoreTests.swift
+++ b/Tests/YMFFTests/Cases/RuntimeOverridesStoreTests.swift
@@ -29,18 +29,18 @@ final class RuntimeOverridesStoreTests: XCTestCase {
             "TEST_key2": "TEST_value2",
         ]
         
-        let value1: String = try await store.value(forKey: "TEST_key1").get()
+        let value1: String = try await store.value(for: "TEST_key1").get()
         XCTAssertEqual(value1, "TEST_value1")
         
         do {
-            let _: Int = try await store.value(forKey: "TEST_key2").get()
+            let _: Int = try await store.value(for: "TEST_key2").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.typeMismatch { } catch {
             XCTFail("Unexpected error: \(error)")
         }
         
         do {
-            let _: Bool = try await store.value(forKey: "TEST_key3").get()
+            let _: Bool = try await store.value(for: "TEST_key3").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.valueNotFound { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -53,18 +53,18 @@ final class RuntimeOverridesStoreTests: XCTestCase {
             "TEST_key2": "TEST_value2",
         ]
         
-        let value1: String = try store.valueSync(forKey: "TEST_key1").get()
+        let value1: String = try store.valueSync(for: "TEST_key1").get()
         XCTAssertEqual(value1, "TEST_value1")
         
         do {
-            let _: Int = try store.valueSync(forKey: "TEST_key2").get()
+            let _: Int = try store.valueSync(for: "TEST_key2").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.typeMismatch { } catch {
             XCTFail("Unexpected error: \(error)")
         }
         
         do {
-            let _: Bool = try store.valueSync(forKey: "TEST_key3").get()
+            let _: Bool = try store.valueSync(for: "TEST_key3").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.valueNotFound { } catch {
             XCTFail("Unexpected error: \(error)")
@@ -74,8 +74,8 @@ final class RuntimeOverridesStoreTests: XCTestCase {
     func test_setValue() async throws {
         store.store = ["TEST_key1": "TEST_value1"]
         
-        try await store.setValue("TEST_newValue1", forKey: "TEST_key1")
-        try await store.setValue("TEST_newValue2", forKey: "TEST_key2")
+        try await store.setValue("TEST_newValue1", for: "TEST_key1")
+        try await store.setValue("TEST_newValue2", for: "TEST_key2")
         
         XCTAssertEqual(store.store["TEST_key1"] as? String, "TEST_newValue1")
         XCTAssertEqual(store.store["TEST_key2"] as? String, "TEST_newValue2")
@@ -84,8 +84,8 @@ final class RuntimeOverridesStoreTests: XCTestCase {
     func test_setValueSync() {
         store.store = ["TEST_key1": "TEST_value1"]
         
-        store.setValueSync("TEST_newValue1", forKey: "TEST_key1")
-        store.setValueSync("TEST_newValue2", forKey: "TEST_key2")
+        store.setValueSync("TEST_newValue1", for: "TEST_key1")
+        store.setValueSync("TEST_newValue2", for: "TEST_key2")
         
         XCTAssertEqual(store.store["TEST_key1"] as? String, "TEST_newValue1")
         XCTAssertEqual(store.store["TEST_key2"] as? String, "TEST_newValue2")
@@ -97,8 +97,8 @@ final class RuntimeOverridesStoreTests: XCTestCase {
             "TEST_key2": "TEST_value2",
         ]
         
-        try await store.removeValue(forKey: "TEST_key1")
-        try await store.removeValue(forKey: "TEST_key999")
+        try await store.removeValue(for: "TEST_key1")
+        try await store.removeValue(for: "TEST_key999")
         
         XCTAssertNil(store.store["TEST_key1"])
         XCTAssertEqual(store.store["TEST_key2"] as? String, "TEST_value2")
@@ -111,8 +111,8 @@ final class RuntimeOverridesStoreTests: XCTestCase {
             "TEST_key2": "TEST_value2",
         ]
         
-        store.removeValueSync(forKey: "TEST_key1")
-        store.removeValueSync(forKey: "TEST_key999")
+        store.removeValueSync(for: "TEST_key1")
+        store.removeValueSync(for: "TEST_key999")
         
         XCTAssertNil(store.store["TEST_key1"])
         XCTAssertEqual(store.store["TEST_key2"] as? String, "TEST_value2")

--- a/Tests/YMFFTests/Cases/RuntimeOverridesStoreTests.swift
+++ b/Tests/YMFFTests/Cases/RuntimeOverridesStoreTests.swift
@@ -1,6 +1,6 @@
 //
 //  RuntimeOverridesStoreTests.swift
-//  YMFF
+//  YMFFTests
 //
 //  Created by Yakov Manshin on 9/26/20.
 //  Copyright © 2020 Yakov Manshin. See the LICENSE file for license info.

--- a/Tests/YMFFTests/Cases/TransparentFeatureFlagStoreTests.swift
+++ b/Tests/YMFFTests/Cases/TransparentFeatureFlagStoreTests.swift
@@ -27,18 +27,18 @@ final class TransparentFeatureFlagStoreTests: XCTestCase {
         store["TEST_key1"] = "TEST_value1"
         store["TEST_key2"] = "TEST_value2"
         
-        let value1: String = try await store.value(forKey: "TEST_key1").get()
+        let value1: String = try await store.value(for: "TEST_key1").get()
         XCTAssertEqual(value1, "TEST_value1")
         
         do {
-            let _: Int = try await store.value(forKey: "TEST_key2").get()
+            let _: Int = try await store.value(for: "TEST_key2").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.typeMismatch { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
         }
         
         do {
-            let _: Bool = try await store.value(forKey: "TEST_key3").get()
+            let _: Bool = try await store.value(for: "TEST_key3").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.valueNotFound { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
@@ -49,18 +49,18 @@ final class TransparentFeatureFlagStoreTests: XCTestCase {
         store["TEST_key1"] = "TEST_value1"
         store["TEST_key2"] = "TEST_value2"
         
-        let value1: String = try store.valueSync(forKey: "TEST_key1").get()
+        let value1: String = try store.valueSync(for: "TEST_key1").get()
         XCTAssertEqual(value1, "TEST_value1")
         
         do {
-            let _: Int = try store.valueSync(forKey: "TEST_key2").get()
+            let _: Int = try store.valueSync(for: "TEST_key2").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.typeMismatch { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
         }
         
         do {
-            let _: Bool = try store.valueSync(forKey: "TEST_key3").get()
+            let _: Bool = try store.valueSync(for: "TEST_key3").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.valueNotFound { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")

--- a/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
@@ -1,6 +1,6 @@
 //
 //  UserDefaultsStoreTests.swift
-//  YMFF
+//  YMFFTests
 //
 //  Created by Yakov Manshin on 3/21/21.
 //  Copyright © 2021 Yakov Manshin. See the LICENSE file for license info.

--- a/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
@@ -41,18 +41,18 @@ final class UserDefaultsStoreTests: XCTestCase {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         userDefaults.set("TEST_value2", forKey: "TEST_key2")
         
-        let value1: String = try await store.value(forKey: "TEST_key1").get()
+        let value1: String = try await store.value(for: "TEST_key1").get()
         XCTAssertEqual(value1, "TEST_value1")
         
         do {
-            let _: Int = try await store.value(forKey: "TEST_key2").get()
+            let _: Int = try await store.value(for: "TEST_key2").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.typeMismatch { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
         }
         
         do {
-            let _: Bool = try await store.value(forKey: "TEST_key3").get()
+            let _: Bool = try await store.value(for: "TEST_key3").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.valueNotFound { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
@@ -63,18 +63,18 @@ final class UserDefaultsStoreTests: XCTestCase {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         userDefaults.set("TEST_value2", forKey: "TEST_key2")
         
-        let value1: String = try store.valueSync(forKey: "TEST_key1").get()
+        let value1: String = try store.valueSync(for: "TEST_key1").get()
         XCTAssertEqual(value1, "TEST_value1")
         
         do {
-            let _: Int = try store.valueSync(forKey: "TEST_key2").get()
+            let _: Int = try store.valueSync(for: "TEST_key2").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.typeMismatch { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
         }
         
         do {
-            let _: Bool = try store.valueSync(forKey: "TEST_key3").get()
+            let _: Bool = try store.valueSync(for: "TEST_key3").get()
             XCTFail("Expected an error")
         } catch FeatureFlagStoreError.valueNotFound { } catch {
             XCTFail("Unexpected error: \(error.localizedDescription)")
@@ -84,8 +84,8 @@ final class UserDefaultsStoreTests: XCTestCase {
     func test_setValue() async throws {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         
-        try await store.setValue("TEST_newValue1", forKey: "TEST_key1")
-        try await store.setValue("TEST_newValue2", forKey: "TEST_key2")
+        try await store.setValue("TEST_newValue1", for: "TEST_key1")
+        try await store.setValue("TEST_newValue2", for: "TEST_key2")
         
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_newValue1")
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_newValue2")
@@ -94,8 +94,8 @@ final class UserDefaultsStoreTests: XCTestCase {
     func test_setValueSync() {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         
-        store.setValueSync("TEST_newValue1", forKey: "TEST_key1")
-        store.setValueSync("TEST_newValue2", forKey: "TEST_key2")
+        store.setValueSync("TEST_newValue1", for: "TEST_key1")
+        store.setValueSync("TEST_newValue2", for: "TEST_key2")
         
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_newValue1")
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_newValue2")
@@ -105,8 +105,8 @@ final class UserDefaultsStoreTests: XCTestCase {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         userDefaults.set("TEST_value2", forKey: "TEST_key2")
         
-        try await store.removeValue(forKey: "TEST_key1")
-        try await store.removeValue(forKey: "TEST_key999")
+        try await store.removeValue(for: "TEST_key1")
+        try await store.removeValue(for: "TEST_key999")
         
         XCTAssertNil(userDefaults.string(forKey: "TEST_key1"))
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_value2")
@@ -117,8 +117,8 @@ final class UserDefaultsStoreTests: XCTestCase {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         userDefaults.set("TEST_value2", forKey: "TEST_key2")
         
-        store.removeValueSync(forKey: "TEST_key1")
-        store.removeValueSync(forKey: "TEST_key999")
+        store.removeValueSync(for: "TEST_key1")
+        store.removeValueSync(for: "TEST_key999")
         
         XCTAssertNil(userDefaults.string(forKey: "TEST_key1"))
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_value2")

--- a/Tests/YMFFTests/Utilities/FeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/FeatureFlagStoreMock.swift
@@ -26,7 +26,7 @@ final class FeatureFlagStoreMock {
 
 extension FeatureFlagStoreMock: FeatureFlagStore {
     
-    func value<Value>(forKey key: String) async -> Result<Value, FeatureFlagStoreError> {
+    func value<Value>(for key: FeatureFlagKey) async -> Result<Value, FeatureFlagStoreError> {
         value_invocationCount += 1
         value_keys.append(key)
         switch value_result! {

--- a/Tests/YMFFTests/Utilities/MutableFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/MutableFeatureFlagStoreMock.swift
@@ -37,7 +37,7 @@ final class MutableFeatureFlagStoreMock {
 
 extension MutableFeatureFlagStoreMock: MutableFeatureFlagStore {
     
-    func value<Value>(forKey key: String) async -> Result<Value, FeatureFlagStoreError> {
+    func value<Value>(for key: FeatureFlagKey) async -> Result<Value, FeatureFlagStoreError> {
         value_invocationCount += 1
         value_keys.append(key)
         switch value_result! {
@@ -51,7 +51,7 @@ extension MutableFeatureFlagStoreMock: MutableFeatureFlagStore {
         }
     }
     
-    func setValue<Value>(_ value: Value, forKey key: String) async throws {
+    func setValue<Value>(_ value: Value, for key: FeatureFlagKey) async throws {
         setValue_invocationCount += 1
         setValue_keyValuePairs.append((key, value))
         if case .failure(let error) = setValue_result {
@@ -59,7 +59,7 @@ extension MutableFeatureFlagStoreMock: MutableFeatureFlagStore {
         }
     }
     
-    func removeValue(forKey key: String) async throws {
+    func removeValue(for key: FeatureFlagKey) async throws {
         removeValue_invocationCount += 1
         removeValue_keys.append(key)
         if case .failure(let error) = removeValue_result {

--- a/Tests/YMFFTests/Utilities/SynchronousFeatureFlagResolverMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousFeatureFlagResolverMock.swift
@@ -16,9 +16,6 @@ import YMFFProtocols
 
 final class SynchronousFeatureFlagResolverMock {
     
-    var configuration_invocationCount = 0
-    var configuration_returnValue: (any FeatureFlagResolverConfiguration)!
-    
     var valueSync_invocationCount = 0
     var valueSync_keys = [FeatureFlagKey]()
     var valueSync_result: Result<Any, any Error>!
@@ -36,11 +33,6 @@ final class SynchronousFeatureFlagResolverMock {
 // MARK: - SynchronousFeatureFlagResolverProtocol
 
 extension SynchronousFeatureFlagResolverMock: SynchronousFeatureFlagResolverProtocol {
-    
-    var configuration: any FeatureFlagResolverConfiguration {
-        configuration_invocationCount += 1
-        return configuration_returnValue
-    }
     
     func valueSync<Value>(for key: FeatureFlagKey) throws -> Value {
         valueSync_invocationCount += 1

--- a/Tests/YMFFTests/Utilities/SynchronousFeatureFlagResolverMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousFeatureFlagResolverMock.swift
@@ -45,15 +45,15 @@ extension SynchronousFeatureFlagResolverMock: SynchronousFeatureFlagResolverProt
         }
     }
     
-    func setValueSync<Value>(_ newValue: Value, toMutableStoreUsing key: FeatureFlagKey) throws {
+    func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws {
         setValueSync_invocationCount += 1
-        setValueSync_keyValuePairs.append((key, newValue))
+        setValueSync_keyValuePairs.append((key, value))
         if case .failure(let error) = setValueSync_result {
             throw error
         }
     }
     
-    func removeValueFromMutableStoreSync(using key: FeatureFlagKey) throws {
+    func removeValueSync(for key: FeatureFlagKey) throws {
         removeValueFromMutableStoreSync_invocationCount += 1
         removeValueFromMutableStoreSync_keys.append(key)
         if case .failure(let error) = removeValueFromMutableStoreSync_result {

--- a/Tests/YMFFTests/Utilities/SynchronousFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousFeatureFlagStoreMock.swift
@@ -26,7 +26,7 @@ final class SynchronousFeatureFlagStoreMock {
 
 extension SynchronousFeatureFlagStoreMock: SynchronousFeatureFlagStore {
     
-    func valueSync<Value>(forKey key: String) -> Result<Value, FeatureFlagStoreError> {
+    func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
         valueSync_invocationCount += 1
         valueSync_keys.append(key)
         switch valueSync_result! {

--- a/Tests/YMFFTests/Utilities/SynchronousMutableFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousMutableFeatureFlagStoreMock.swift
@@ -37,7 +37,7 @@ final class SynchronousMutableFeatureFlagStoreMock {
 
 extension SynchronousMutableFeatureFlagStoreMock: SynchronousMutableFeatureFlagStore {
     
-    func valueSync<Value>(forKey key: String) -> Result<Value, FeatureFlagStoreError> {
+    func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
         valueSync_invocationCount += 1
         valueSync_keys.append(key)
         switch valueSync_result! {
@@ -51,7 +51,7 @@ extension SynchronousMutableFeatureFlagStoreMock: SynchronousMutableFeatureFlagS
         }
     }
     
-    func setValueSync<Value>(_ value: Value, forKey key: String) throws {
+    func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws {
         setValueSync_invocationCount += 1
         setValueSync_keyValuePairs.append((key, value))
         if case .failure(let error) = setValueSync_result {
@@ -59,7 +59,7 @@ extension SynchronousMutableFeatureFlagStoreMock: SynchronousMutableFeatureFlagS
         }
     }
     
-    func removeValueSync(forKey key: String) throws {
+    func removeValueSync(for key: FeatureFlagKey) throws {
         removeValueSync_invocationCount += 1
         removeValueSync_keys.append(key)
         if case .failure(let error) = removeValueSync_result {


### PR DESCRIPTION
[Closes #145]

* Renamed feature-flag stores’ methods
* Renamed resolver’s methods
* Renamed `FeatureFlag.removeValueFromMutableStore()` to `FeatureFlag.removeValueFromMutableStores()`
* Removed `FeatureFlagResolverProtocol.configuration`
* Updated `FeatureFlagResolver.Error`
* Updated resolver’s initializer
* Updated file headers