### PR TITLE
[#148] Removed `saveChanges()`

### DIFF
--- a/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
+++ b/Sources/YMFF/FeatureFlagResolver/FeatureFlagResolver.swift
@@ -38,15 +38,6 @@ final public class FeatureFlagResolver {
         self.init(configuration: configuration)
     }
     
-    deinit {
-        let mutableStores = getMutableStores()
-        Task { [mutableStores] in
-            for store in mutableStores {
-                try? await store.saveChanges()
-            }
-        }
-    }
-    
 }
 
 // MARK: - FeatureFlagResolverProtocol

--- a/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
@@ -28,6 +28,10 @@ final public class UserDefaultsStore {
         self.userDefaults = userDefaults
     }
     
+    deinit {
+        userDefaults.synchronize()
+    }
+    
 }
 
 // MARK: - SynchronousMutableFeatureFlagStore
@@ -46,10 +50,6 @@ extension UserDefaultsStore: SynchronousMutableFeatureFlagStore {
     
     public func removeValueSync(for key: FeatureFlagKey) {
         userDefaults.removeObject(forKey: key)
-    }
-    
-    public func saveChangesSync() {
-        userDefaults.synchronize()
     }
     
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Store/MutableFeatureFlagStore.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Store/MutableFeatureFlagStore.swift
@@ -21,18 +21,4 @@ public protocol MutableFeatureFlagStore: AnyObject, FeatureFlagStore {
     /// - Parameter key: *Required.* The key used to address the value.
     func removeValue(for key: FeatureFlagKey) async throws
     
-    /// Immediately saves changed values so they’re not lost.
-    ///
-    /// + This method can be called when work with the feature flag store is finished.
-    func saveChanges() async throws
-    
-}
-
-// MARK: - Default Implementation
-
-extension MutableFeatureFlagStore {
-    
-    // Not all kinds of feature flag stores need this method, so it’s optional to implement.
-    public func saveChanges() async throws { }
-    
 }

--- a/Sources/YMFFProtocols/FeatureFlagResolver/Store/SynchronousMutableFeatureFlagStore.swift
+++ b/Sources/YMFFProtocols/FeatureFlagResolver/Store/SynchronousMutableFeatureFlagStore.swift
@@ -20,11 +20,6 @@ public protocol SynchronousMutableFeatureFlagStore: SynchronousFeatureFlagStore,
     /// - Parameter key: *Required.* The key used to address the value.
     func removeValueSync(for key: FeatureFlagKey) throws
     
-    /// Immediately saves changed values so they’re not lost.
-    ///
-    /// + This method can be called when work with the feature flag store is finished.
-    func saveChangesSync() throws
-    
 }
 
 // MARK: - Async Requirements
@@ -38,17 +33,5 @@ extension SynchronousMutableFeatureFlagStore {
     public func removeValue(for key: FeatureFlagKey) async throws {
         try removeValueSync(for: key)
     }
-    
-    public func saveChanges() async throws {
-        try saveChangesSync()
-    }
-    
-}
-
-// MARK: - Default Implementation
-
-extension SynchronousMutableFeatureFlagStore {
-    
-    public func saveChangesSync() throws { }
     
 }

--- a/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagResolverTests.swift
@@ -1038,18 +1038,4 @@ final class FeatureFlagResolverTests: XCTestCase {
         }
     }
     
-    func test_deinit() async throws {
-        let store1 = MutableFeatureFlagStoreMock()
-        let store2 = SynchronousMutableFeatureFlagStoreMock()
-        configuration.stores = [store1, store2]
-        
-        configuration = nil
-        resolver = nil
-        
-        try await Task.sleep(nanoseconds: 1_000_000)
-        
-        XCTAssertEqual(store1.saveChanges_invocationCount, 1)
-        XCTAssertEqual(store2.saveChangesSync_invocationCount, 1)
-    }
-    
 }

--- a/Tests/YMFFTests/Utilities/MutableFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/MutableFeatureFlagStoreMock.swift
@@ -28,9 +28,6 @@ final class MutableFeatureFlagStoreMock {
     var removeValue_keys = [String]()
     var removeValue_result: Result<Void, TestFeatureFlagStoreError>!
     
-    var saveChanges_invocationCount = 0
-    var saveChanges_result: Result<Void, TestFeatureFlagStoreError>!
-    
 }
 
 // MARK: - MutableFeatureFlagStore
@@ -63,13 +60,6 @@ extension MutableFeatureFlagStoreMock: MutableFeatureFlagStore {
         removeValue_invocationCount += 1
         removeValue_keys.append(key)
         if case .failure(let error) = removeValue_result {
-            throw error
-        }
-    }
-    
-    func saveChanges() async throws {
-        saveChanges_invocationCount += 1
-        if case .failure(let error) = saveChanges_result {
             throw error
         }
     }

--- a/Tests/YMFFTests/Utilities/SynchronousMutableFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousMutableFeatureFlagStoreMock.swift
@@ -28,9 +28,6 @@ final class SynchronousMutableFeatureFlagStoreMock {
     var removeValueSync_keys = [String]()
     var removeValueSync_result: Result<Void, TestFeatureFlagStoreError>!
     
-    var saveChangesSync_invocationCount = 0
-    var saveChangesSync_result: Result<Void, TestFeatureFlagStoreError>!
-    
 }
 
 // MARK: - SynchronousMutableFeatureFlagStore
@@ -63,13 +60,6 @@ extension SynchronousMutableFeatureFlagStoreMock: SynchronousMutableFeatureFlagS
         removeValueSync_invocationCount += 1
         removeValueSync_keys.append(key)
         if case .failure(let error) = removeValueSync_result {
-            throw error
-        }
-    }
-    
-    func saveChangesSync() throws {
-        saveChangesSync_invocationCount += 1
-        if case .failure(let error) = saveChangesSync_result {
             throw error
         }
     }


### PR DESCRIPTION
[Closes #148]

* The `saveChanges()` method was not needed for the majority of feature-flag stores
* Only `UserDefaultsStore` had this method implemented
* This change removes the method from protocols for mutable feature-flag stores
* `UserDefaultsStore` synchronizes the changes in `deinit`
* If a custom feature-flag store needs to save changes explicitly, it should implement an internal way to do so