### PR TITLE
[#147] Crash Fix for Optionals in `UserDefaultsStore`

### DIFF
--- a/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
@@ -54,4 +54,14 @@ extension UserDefaultsStore: SynchronousMutableFeatureFlagStore {
     
 }
 
+// MARK: - Error
+
+extension UserDefaultsStore {
+    
+    enum Error: Swift.Error {
+        case optionalValuesAreNotSupported
+    }
+    
+}
+
 #endif

--- a/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
@@ -39,12 +39,20 @@ final public class UserDefaultsStore {
 extension UserDefaultsStore: SynchronousMutableFeatureFlagStore {
     
     public func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
+        guard !(Value.self is ExpressibleByNilLiteral.Type) else {
+            return .failure(.otherError(Error.optionalValuesAreNotSupported))
+        }
+        
         guard let anyValue = userDefaults.object(forKey: key) else { return .failure(.valueNotFound) }
         guard let value = anyValue as? Value else { return .failure(.typeMismatch) }
         return .success(value)
     }
     
     public func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws {
+        guard !(value is ExpressibleByNilLiteral) else {
+            throw FeatureFlagStoreError.otherError(Error.optionalValuesAreNotSupported)
+        }
+        
         userDefaults.set(value, forKey: key)
     }
     

--- a/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
+++ b/Sources/YMFF/FeatureFlagResolver/Store/UserDefaultsStore.swift
@@ -44,7 +44,7 @@ extension UserDefaultsStore: SynchronousMutableFeatureFlagStore {
         return .success(value)
     }
     
-    public func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) {
+    public func setValueSync<Value>(_ value: Value, for key: FeatureFlagKey) throws {
         userDefaults.set(value, forKey: key)
     }
     

--- a/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
@@ -91,11 +91,11 @@ final class UserDefaultsStoreTests: XCTestCase {
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_newValue2")
     }
     
-    func test_setValueSync() {
+    func test_setValueSync() throws {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         
-        store.setValueSync("TEST_newValue1", for: "TEST_key1")
-        store.setValueSync("TEST_newValue2", for: "TEST_key2")
+        try store.setValueSync("TEST_newValue1", for: "TEST_key1")
+        try store.setValueSync("TEST_newValue2", for: "TEST_key2")
         
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_newValue1")
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_newValue2")

--- a/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
+++ b/Tests/YMFFTests/Cases/UserDefaultsStoreTests.swift
@@ -81,6 +81,52 @@ final class UserDefaultsStoreTests: XCTestCase {
         }
     }
     
+    func test_value_optionals() async {
+        userDefaults.set("TEST_value1", forKey: "TEST_key1")
+        // No record for TEST_key2
+        
+        do {
+            let _: String? = try await store.value(for: "TEST_key1").get()
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) { 
+            XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_value1")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+        do {
+            let _: String? = try await store.value(for: "TEST_key2").get()
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) { 
+            XCTAssertNil(userDefaults.string(forKey: "TEST_key2"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func test_valueSync_optionals() {
+        userDefaults.set("TEST_value1", forKey: "TEST_key1")
+        // No record for TEST_key2
+        
+        do {
+            let _: String? = try store.valueSync(for: "TEST_key1").get()
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) { 
+            XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_value1")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+        do {
+            let _: String? = try store.valueSync(for: "TEST_key2").get()
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) { 
+            XCTAssertNil(userDefaults.string(forKey: "TEST_key2"))
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
     func test_setValue() async throws {
         userDefaults.set("TEST_value1", forKey: "TEST_key1")
         
@@ -99,6 +145,56 @@ final class UserDefaultsStoreTests: XCTestCase {
         
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_newValue1")
         XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_newValue2")
+    }
+    
+    func test_setValue_optionals() async {
+        userDefaults.set("TEST_value1", forKey: "TEST_key1")
+        userDefaults.set("TEST_value2", forKey: "TEST_key2")
+        
+        do {
+            let optionalValue1: String? = "TEST_newValue1"
+            try await store.setValue(optionalValue1, for: "TEST_key1")
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) {
+            XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_value1")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+        do {
+            let optionalValue2: String? = nil
+            try await store.setValue(optionalValue2, for: "TEST_key2")
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) {
+            XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_value2")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+    
+    func test_setValueSync_optionals() {
+        userDefaults.set("TEST_value1", forKey: "TEST_key1")
+        userDefaults.set("TEST_value2", forKey: "TEST_key2")
+        
+        do {
+            let optionalValue1: String? = "TEST_newValue1"
+            try store.setValueSync(optionalValue1, for: "TEST_key1")
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) {
+            XCTAssertEqual(userDefaults.string(forKey: "TEST_key1"), "TEST_value1")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+        do {
+            let optionalValue2: String? = nil
+            try store.setValueSync(optionalValue2, for: "TEST_key2")
+            XCTFail("Expected an error")
+        } catch FeatureFlagStoreError.otherError(UserDefaultsStore.Error.optionalValuesAreNotSupported) {
+            XCTAssertEqual(userDefaults.string(forKey: "TEST_key2"), "TEST_value2")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
     
     func test_removeValue() async throws {


### PR DESCRIPTION
[Closes #147]

* `UserDefaults` does not accept `nil` as the value in a record
* Upon finding a `nil`, `UserDefaults` raises an exception which crashes the client app
* This fix does not add complete support for optionals but addresses the crash by checking the type against the `ExpressibleByNilLiteral` protocol and throwing the `optionalValuesAreNotSupported` error
* Complete support for optionals in `UserDefaultsStore` is planned for #150