### PR TITLE
[#144] Updated Minimum Swift Version to 5.9

### DIFF
--- a/.github/workflows/Common.yml
+++ b/.github/workflows/Common.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        SWIFT_VERSION: ["5.10", "5.9", "5.8"]
+        SWIFT_VERSION: ["5.10", "5.9"]
         include:
           - SWIFT_VERSION: "5.10"
             OS: macos-14
@@ -31,9 +31,6 @@ jobs:
           - SWIFT_VERSION: "5.9"
             OS: macos-13
             XCODE_APP_NAME: "Xcode_15.2"
-          - SWIFT_VERSION: "5.8"
-            OS: macos-13
-            XCODE_APP_NAME: "Xcode_14.3.1"
     steps:
     - uses: actions/checkout@v4
     - name: Select Xcode Version

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 
 import PackageDescription
 

--- a/Tests/YMFFTests/Cases/FeatureFlagValueTransformerTests.swift
+++ b/Tests/YMFFTests/Cases/FeatureFlagValueTransformerTests.swift
@@ -81,23 +81,16 @@ final class FeatureFlagValueTransformerTests: XCTestCase {
     func test_valueFromRawValue_enumFromInt() {
         let transformer = FeatureFlagValueTransformer { (age: Int) -> AgeGroup in
             switch age {
-            case ..<13:
-                return .under13
-            case 13...17:
-                return .between13And17
-            case 18...:
-                return .over17
-            default:
-                return .under13
+            case ..<13: .under13
+            case 13...17: .between13And17
+            case 18...: .over17
+            default: .under13
             }
         } rawValueFromValue: { group in
             switch group {
-            case .under13:
-                return 13
-            case .between13And17:
-                return 17
-            case .over17:
-                return 18
+            case .under13: 13
+            case .between13And17: 17
+            case .over17: 18
             }
         }
         

--- a/Tests/YMFFTests/Utilities/FeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/FeatureFlagStoreMock.swift
@@ -29,14 +29,14 @@ extension FeatureFlagStoreMock: FeatureFlagStore {
     func value<Value>(for key: FeatureFlagKey) async -> Result<Value, FeatureFlagStoreError> {
         value_invocationCount += 1
         value_keys.append(key)
-        switch value_result! {
+        return switch value_result! {
         case .success(let anyValue):
             if let value = anyValue as? Value {
-                return .success(value)
+                .success(value)
             } else {
-                return .failure(.typeMismatch)
+                .failure(.typeMismatch)
             }
-        case .failure(let error): return .failure(error)
+        case .failure(let error): .failure(error)
         }
     }
     

--- a/Tests/YMFFTests/Utilities/MutableFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/MutableFeatureFlagStoreMock.swift
@@ -37,14 +37,14 @@ extension MutableFeatureFlagStoreMock: MutableFeatureFlagStore {
     func value<Value>(for key: FeatureFlagKey) async -> Result<Value, FeatureFlagStoreError> {
         value_invocationCount += 1
         value_keys.append(key)
-        switch value_result! {
+        return switch value_result! {
         case .success(let anyValue):
             if let value = anyValue as? Value {
-                return .success(value)
+                .success(value)
             } else {
-                return .failure(.typeMismatch)
+                .failure(.typeMismatch)
             }
-        case .failure(let error): return .failure(error)
+        case .failure(let error): .failure(error)
         }
     }
     

--- a/Tests/YMFFTests/Utilities/SynchronousFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousFeatureFlagStoreMock.swift
@@ -29,14 +29,14 @@ extension SynchronousFeatureFlagStoreMock: SynchronousFeatureFlagStore {
     func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
         valueSync_invocationCount += 1
         valueSync_keys.append(key)
-        switch valueSync_result! {
+        return switch valueSync_result! {
         case .success(let anyValue):
             if let value = anyValue as? Value {
-                return .success(value)
+                .success(value)
             } else {
-                return .failure(.typeMismatch)
+                .failure(.typeMismatch)
             }
-        case .failure(let error): return .failure(error)
+        case .failure(let error): .failure(error)
         }
     }
     

--- a/Tests/YMFFTests/Utilities/SynchronousMutableFeatureFlagStoreMock.swift
+++ b/Tests/YMFFTests/Utilities/SynchronousMutableFeatureFlagStoreMock.swift
@@ -37,14 +37,14 @@ extension SynchronousMutableFeatureFlagStoreMock: SynchronousMutableFeatureFlagS
     func valueSync<Value>(for key: FeatureFlagKey) -> Result<Value, FeatureFlagStoreError> {
         valueSync_invocationCount += 1
         valueSync_keys.append(key)
-        switch valueSync_result! {
+        return switch valueSync_result! {
         case .success(let anyValue):
             if let value = anyValue as? Value {
-                return .success(value)
+                .success(value)
             } else {
-                return .failure(.typeMismatch)
+                .failure(.typeMismatch)
             }
-        case .failure(let error): return .failure(error)
+        case .failure(let error): .failure(error)
         }
     }
     

--- a/YMFF.podspec
+++ b/YMFF.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   
   s.name              = "YMFF"
   s.version           = "4.0.0"
-  s.swift_version     = "5.8"
+  s.swift_version     = "5.9"
   s.authors           = { "Yakov Manshin" => "git@yakovmanshin.com" }
   s.license           = { :type => "Apache License, version 2.0", :file => "LICENSE" }
   s.homepage          = "https://github.com/yakovmanshin/YMFF"


### PR DESCRIPTION
[Closes #144]

* Updated the minimum compiler version to Swift 5.9
* Removed testing with Swift 5.8 from the GitHub Actions workflow
* Updated source code to modern syntax